### PR TITLE
Improve sync, selected header size fix, sort liked fix

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -62,6 +62,7 @@ val SongFilterKey = stringPreferencesKey("songFilter")
 val ArtistFilterKey = stringPreferencesKey("artistFilter")
 val ArtistViewTypeKey = stringPreferencesKey("artistViewType")
 val AlbumFilterKey = stringPreferencesKey("albumFilter")
+val PlaylistFilterKey = stringPreferencesKey("playlistFilter")
 val AlbumViewTypeKey = stringPreferencesKey("albumViewType")
 val PlaylistViewTypeKey = stringPreferencesKey("playlistViewType")
 val LibraryFilterKey = stringPreferencesKey("libraryFilter")
@@ -116,6 +117,10 @@ enum class ArtistFilter {
 
 enum class AlbumFilter {
     LIBRARY, LIKED
+}
+
+enum class PlaylistFilter {
+    LIBRARY, DOWNLOADED
 }
 
 enum class LibraryFilter {

--- a/app/src/main/java/com/dd3boh/outertune/db/DatabaseDao.kt
+++ b/app/src/main/java/com/dd3boh/outertune/db/DatabaseDao.kt
@@ -134,11 +134,11 @@ interface DatabaseDao {
     fun likedSongsByCreateDateAsc(): Flow<List<Song>>
 
     @Transaction
-    @Query("SELECT * FROM song WHERE liked IS NOT NULL ORDER BY date")
+    @Query("SELECT * FROM song WHERE liked ORDER BY date")
     fun likedSongsByReleaseDateAsc(): Flow<List<Song>>
 
     @Transaction
-    @Query("SELECT * FROM song WHERE liked IS NOT NULL ORDER BY dateModified")
+    @Query("SELECT * FROM song WHERE liked ORDER BY dateModified")
     fun likedSongsByDateModifiedAsc(): Flow<List<Song>>
 
     @Transaction
@@ -164,9 +164,9 @@ interface DatabaseDao {
     fun likedSongs(sortType: SongSortType, descending: Boolean) =
         when (sortType) {
             SongSortType.CREATE_DATE -> likedSongsByCreateDateAsc()
-            SongSortType.MODIFIED_DATE -> songsByDateModifiedAsc()
+            SongSortType.MODIFIED_DATE -> likedSongsByDateModifiedAsc()
             SongSortType.RELEASE_DATE -> {
-                val songs = songsByReleaseDateAsc()
+                val songs = likedSongsByReleaseDateAsc()
                 runBlocking {
                     flowOf(songs.first().sortedBy {
                         it.song.getDateLong()

--- a/app/src/main/java/com/dd3boh/outertune/ui/component/ChipsRow.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/ChipsRow.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.MaterialTheme
@@ -27,6 +29,7 @@ fun <E> ChipsRow(
     currentValue: E,
     onValueUpdate: (E) -> Unit,
     modifier: Modifier = Modifier,
+    isLoading: (E) -> Boolean = { false }
 ) {
     Row(
         modifier = modifier
@@ -40,7 +43,15 @@ fun <E> ChipsRow(
                 label = { Text(label) },
                 selected = currentValue == value,
                 colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
-                onClick = { onValueUpdate(value) }
+                onClick = { onValueUpdate(value) },
+                trailingIcon = {
+                    if (isLoading(value)) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp
+                        )
+                    }
+                }
             )
 
             Spacer(Modifier.width(8.dp))
@@ -56,6 +67,7 @@ fun <E> ChipsLazyRow(
     onValueUpdate: (E) -> Unit,
     modifier: Modifier = Modifier,
     selected: ((E) -> Boolean)? = null,
+    isLoading: (E) -> Boolean = { false }
 ) {
     val tween: FiniteAnimationSpec<IntOffset> = tween(
         durationMillis = 200,
@@ -81,7 +93,15 @@ fun <E> ChipsLazyRow(
                 selected = selected?.let { it(value) } ?: (currentValue == value),
                 colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
                 onClick = { onValueUpdate(value) },
-                modifier = Modifier.animateItemPlacement(tween)
+                modifier = Modifier.animateItemPlacement(tween),
+                trailingIcon = {
+                    if (isLoading(value)) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp
+                        )
+                    }
+                }
             )
 
             Spacer(Modifier.width(8.dp))

--- a/app/src/main/java/com/dd3boh/outertune/ui/component/SelectHeader.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/SelectHeader.kt
@@ -1,7 +1,6 @@
 package com.dd3boh.outertune.ui.component
 
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
@@ -42,8 +41,6 @@ private fun SelectHeaderContent(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
-
-        Spacer(Modifier.weight(1f)) // or adjust as needed
 
         IconButton(onClick = onSelectAllToggle) {
             Icon(

--- a/app/src/main/java/com/dd3boh/outertune/ui/component/SelectHeader.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/SelectHeader.kt
@@ -1,6 +1,7 @@
 package com.dd3boh.outertune.ui.component
 
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
@@ -13,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.dd3boh.outertune.db.entities.PlaylistSong
 import com.dd3boh.outertune.db.entities.Song
@@ -22,70 +24,68 @@ import com.dd3boh.outertune.ui.menu.SelectionSongMenu
 import com.dd3boh.outertune.ui.utils.ItemWrapper
 import com.zionhuang.innertube.models.SongItem
 
+@Composable
+private fun SelectHeaderContent(
+    count: Int,
+    total: Int,
+    onSelectAllToggle: () -> Unit,
+    onMenuClick: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(top = 2.dp, bottom = 3.dp)
+    ) {
+        Text(
+            text = "${count}/${total} selected",
+            modifier = Modifier.weight(1f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        Spacer(Modifier.weight(1f)) // or adjust as needed
+
+        IconButton(onClick = onSelectAllToggle) {
+            Icon(
+                imageVector = if (count == total) Icons.Rounded.Deselect else Icons.Rounded.SelectAll,
+                contentDescription = null
+            )
+        }
+
+        IconButton(onClick = onMenuClick) {
+            Icon(Icons.Rounded.MoreVert, contentDescription = null)
+        }
+
+        IconButton(onClick = onDismiss) {
+            Icon(Icons.Rounded.Close, contentDescription = null)
+        }
+    }
+}
 
 @Composable
 fun SelectHeader(
     wrappedSongs: MutableList<ItemWrapper<PlaylistSong>>,
     menuState: MenuState,
     onDismiss: (() -> Unit)? = null,
-    jvmHax: Boolean
+    jvmHax: Boolean // Remove if not needed
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.padding(horizontal = 16.dp)
-    ) {
-        val count = wrappedSongs.count { it.isSelected }
-        Text(
-            text = "${count}/${wrappedSongs.size} selected",
-            modifier = Modifier.weight(1f)
-        )
-        IconButton(
-            onClick = {
-                if (count == wrappedSongs.size) {
-                    wrappedSongs.forEach { it.isSelected = false }
-                } else {
-                    wrappedSongs.forEach { it.isSelected = true }
-                }
-            },
-        ) {
-            Icon(
-                if (count == wrappedSongs.size) Icons.Rounded.Deselect else Icons.Rounded.SelectAll,
-                contentDescription = null
-            )
-        }
+    val count = wrappedSongs.count { it.isSelected }
 
-        IconButton(
-            onClick = {
-                menuState.show {
-                    SelectionSongMenu(
-                        songSelection = wrappedSongs.filter { it.isSelected }.map { it.item.song },
-                        onDismiss = menuState::dismiss,
-                        clearAction = {
-                            wrappedSongs.forEach { it.isSelected = false }
-                            onDismiss?.invoke()
-                        }
-                    )
-                }
-            },
-        ) {
-            Icon(
-                Icons.Rounded.MoreVert,
-                contentDescription = null
-            )
-        }
-
-        IconButton(
-            onClick = {
-                wrappedSongs.forEach { it.isSelected = false }
-                onDismiss?.invoke()
-            },
-        ) {
-            Icon(
-                Icons.Rounded.Close,
-                contentDescription = null
-            )
-        }
-    }
+    SelectHeaderContent(
+        count = count,
+        total = wrappedSongs.size,
+        onSelectAllToggle = { wrappedSongs.forEach { it.isSelected = !it.isSelected } },
+        onMenuClick = {
+            menuState.show {
+                SelectionSongMenu(
+                    songSelection = wrappedSongs.filter { it.isSelected }.map { it.item.song },
+                    onDismiss = menuState::dismiss,
+                    clearAction = { wrappedSongs.forEach { it.isSelected = false }; onDismiss?.invoke() }
+                )
+            }
+        },
+        onDismiss = { wrappedSongs.forEach { it.isSelected = false }; onDismiss?.invoke() }
+    )
 }
 
 @Composable
@@ -93,67 +93,27 @@ fun SelectHeader(
     wrappedSongs: MutableList<ItemWrapper<SongItem>>,
     menuState: MenuState,
     onDismiss: (() -> Unit)? = null,
-    jvmHax: Int
+    jvmHax: Int // Remove if not needed
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.padding(horizontal = 16.dp)
-    ) {
-        val count = wrappedSongs.count { it.isSelected }
-        Text(
-            text = "${count}/${wrappedSongs.size} selected",
-            modifier = Modifier.weight(1f)
-        )
-        IconButton(
-            onClick = {
-                if (count == wrappedSongs.size) {
-                    wrappedSongs.forEach { it.isSelected = false }
-                } else {
-                    wrappedSongs.forEach { it.isSelected = true }
-                }
-            },
-        ) {
-            Icon(
-                if (count == wrappedSongs.size) Icons.Rounded.Deselect else Icons.Rounded.SelectAll,
-                contentDescription = null
-            )
-        }
+    val count = wrappedSongs.count { it.isSelected }
 
-        IconButton(
-            onClick = {
-                menuState.show {
-                    SelectionMediaMetadataMenu(
-                        songSelection = wrappedSongs.filter { it.isSelected }.map { it.item.toMediaMetadata() },
-                        onDismiss = menuState::dismiss,
-                        currentItems = emptyList(),
-                        clearAction = {
-                            wrappedSongs.forEach { it.isSelected = false }
-                            onDismiss?.invoke()
-                        }
-                    )
-                }
-            },
-        ) {
-            Icon(
-                Icons.Rounded.MoreVert,
-                contentDescription = null
-            )
-        }
-
-        IconButton(
-            onClick = {
-                wrappedSongs.forEach { it.isSelected = false }
-                onDismiss?.invoke()
-            },
-        ) {
-            Icon(
-                Icons.Rounded.Close,
-                contentDescription = null
-            )
-        }
-    }
+    SelectHeaderContent(
+        count = count,
+        total = wrappedSongs.size,
+        onSelectAllToggle = { wrappedSongs.forEach { it.isSelected = !it.isSelected } },
+        onMenuClick = {
+            menuState.show {
+                SelectionMediaMetadataMenu(
+                    songSelection = wrappedSongs.filter { it.isSelected }.map { it.item.toMediaMetadata() },
+                    onDismiss = menuState::dismiss,
+                    currentItems = emptyList(),
+                    clearAction = { wrappedSongs.forEach { it.isSelected = false }; onDismiss?.invoke() }
+                )
+            }
+        },
+        onDismiss = { wrappedSongs.forEach { it.isSelected = false }; onDismiss?.invoke() }
+    )
 }
-
 
 @Composable
 fun SelectHeader(
@@ -161,60 +121,21 @@ fun SelectHeader(
     menuState: MenuState,
     onDismiss: (() -> Unit)? = null
 ) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.padding(horizontal = 16.dp)
-    ) {
-        val count = wrappedSongs.count { it.isSelected }
-        Text(
-            text = "${count}/${wrappedSongs.size} selected",
-            modifier = Modifier.weight(1f)
-        )
-        IconButton(
-            onClick = {
-                if (count == wrappedSongs.size) {
-                    wrappedSongs.forEach { it.isSelected = false }
-                } else {
-                    wrappedSongs.forEach { it.isSelected = true }
-                }
-            },
-        ) {
-            Icon(
-                if (count == wrappedSongs.size) Icons.Rounded.Deselect else Icons.Rounded.SelectAll,
-                contentDescription = null
-            )
-        }
+    val count = wrappedSongs.count { it.isSelected }
 
-        IconButton(
-            onClick = {
-                menuState.show {
-                    SelectionSongMenu(
-                        songSelection = wrappedSongs.filter { it.isSelected }.map { it.item },
-                        onDismiss = menuState::dismiss,
-                        clearAction = {
-                            wrappedSongs.forEach { it.isSelected = false }
-                            onDismiss?.invoke()
-                        }
-                    )
-                }
-            },
-        ) {
-            Icon(
-                Icons.Rounded.MoreVert,
-                contentDescription = null
-            )
-        }
-
-        IconButton(
-            onClick = {
-                wrappedSongs.forEach { it.isSelected = false }
-                onDismiss?.invoke()
-            },
-        ) {
-            Icon(
-                Icons.Rounded.Close,
-                contentDescription = null
-            )
-        }
-    }
+    SelectHeaderContent(
+        count = count,
+        total = wrappedSongs.size,
+        onSelectAllToggle = { wrappedSongs.forEach { it.isSelected = !it.isSelected } },
+        onMenuClick = {
+            menuState.show {
+                SelectionSongMenu(
+                    songSelection = wrappedSongs.filter { it.isSelected }.map { it.item },
+                    onDismiss = menuState::dismiss,
+                    clearAction = { wrappedSongs.forEach { it.isSelected = false }; onDismiss?.invoke() }
+                )
+            }
+        },
+        onDismiss = { wrappedSongs.forEach { it.isSelected = false }; onDismiss?.invoke() }
+    )
 }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -57,6 +57,8 @@ import com.dd3boh.outertune.constants.CONTENT_TYPE_PLAYLIST
 import com.dd3boh.outertune.constants.GridThumbnailHeight
 import com.dd3boh.outertune.constants.LibraryViewType
 import com.dd3boh.outertune.constants.LibraryViewTypeKey
+import com.dd3boh.outertune.constants.PlaylistFilter
+import com.dd3boh.outertune.constants.PlaylistFilterKey
 import com.dd3boh.outertune.constants.PlaylistSortDescendingKey
 import com.dd3boh.outertune.constants.PlaylistSortType
 import com.dd3boh.outertune.constants.PlaylistSortTypeKey
@@ -65,6 +67,7 @@ import com.dd3boh.outertune.constants.YtmSyncKey
 import com.dd3boh.outertune.db.entities.PlaylistEntity
 import com.dd3boh.outertune.ui.component.AutoPlaylistGridItem
 import com.dd3boh.outertune.ui.component.AutoPlaylistListItem
+import com.dd3boh.outertune.ui.component.ChipsRow
 import com.dd3boh.outertune.ui.component.HideOnScrollFAB
 import com.dd3boh.outertune.ui.component.LibraryPlaylistGridItem
 import com.dd3boh.outertune.ui.component.LibraryPlaylistListItem
@@ -88,19 +91,21 @@ fun LibraryPlaylistsScreen(
 ) {
     val menuState = LocalMenuState.current
     val database = LocalDatabase.current
-
     val coroutineScope = rememberCoroutineScope()
 
-    var viewTypeLocal by rememberEnumPreference(PlaylistViewTypeKey, LibraryViewType.GRID)
-    val libraryViewType by rememberEnumPreference(LibraryViewTypeKey, LibraryViewType.GRID)
+    var filter by rememberEnumPreference(PlaylistFilterKey, PlaylistFilter.LIBRARY)
+    libraryFilterContent?.let { filter = PlaylistFilter.LIBRARY }
 
-    val viewType = if (libraryFilterContent != null) libraryViewType else viewTypeLocal
+    var playlistViewType by rememberEnumPreference(PlaylistViewTypeKey, LibraryViewType.GRID)
+    val libraryViewType by rememberEnumPreference(LibraryViewTypeKey, LibraryViewType.GRID)
+    val viewType = if (libraryFilterContent != null) libraryViewType else playlistViewType
 
     val (sortType, onSortTypeChange) = rememberEnumPreference(PlaylistSortTypeKey, PlaylistSortType.CREATE_DATE)
     val (sortDescending, onSortDescendingChange) = rememberPreference(PlaylistSortDescendingKey, true)
     val (ytmSync) = rememberPreference(YtmSyncKey, true)
 
     val playlists by viewModel.allPlaylists.collectAsState()
+    val isSyncingRemotePlaylists by viewModel.isSyncingRemotePlaylists.collectAsState()
 
     val likedPlaylist = PlaylistEntity(id = "liked", name = stringResource(id = R.string.liked_songs))
     val downloadedPlaylist = PlaylistEntity(id = "downloaded", name = stringResource(id = R.string.downloaded_songs))
@@ -110,17 +115,18 @@ fun LibraryPlaylistsScreen(
     val backStackEntry by navController.currentBackStackEntryAsState()
     val scrollToTop = backStackEntry?.savedStateHandle?.getStateFlow("scrollToTop", false)?.collectAsState()
 
-    var showAddPlaylistDialog by rememberSaveable {
-        mutableStateOf(false)
-    }
+    var showAddPlaylistDialog by rememberSaveable { mutableStateOf(false) }
+    var syncedPlaylist: Boolean by remember { mutableStateOf(false) }
 
-    var syncedPlaylist: Boolean by remember {
-        mutableStateOf(false)
-    }
+    LaunchedEffect(Unit) { viewModel.sync() }
 
-    LaunchedEffect(Unit) {
-        if (ytmSync) {
-            viewModel.sync()
+    LaunchedEffect(scrollToTop?.value) {
+        if (scrollToTop?.value == true) {
+            when (viewType) {
+                LibraryViewType.LIST -> lazyListState.animateScrollToItem(0)
+                LibraryViewType.GRID -> lazyGridState.animateScrollToItem(0)
+            }
+            backStackEntry?.savedStateHandle?.set("scrollToTop", false)
         }
     }
 
@@ -180,6 +186,25 @@ fun LibraryPlaylistsScreen(
         )
     }
 
+    val filterContent = @Composable {
+        ChipsRow(
+            chips = listOf(
+                PlaylistFilter.LIBRARY to stringResource(R.string.filter_library),
+                PlaylistFilter.DOWNLOADED to stringResource(R.string.filter_downloaded)
+            ),
+            currentValue = filter,
+            onValueUpdate = {
+                filter = it
+                if (ytmSync) {
+                    if (it == PlaylistFilter.LIBRARY) viewModel.sync()
+                }
+            },
+            isLoading = { filter ->
+                filter == PlaylistFilter.LIBRARY && isSyncingRemotePlaylists
+            }
+        )
+    }
+
     val headerContent = @Composable {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -210,13 +235,13 @@ fun LibraryPlaylistsScreen(
             if (libraryFilterContent == null) {
                 IconButton(
                     onClick = {
-                        viewTypeLocal = viewTypeLocal.toggle()
+                        playlistViewType = playlistViewType.toggle()
                     },
                     modifier = Modifier.padding(start = 6.dp, end = 6.dp)
                 ) {
                     Icon(
                         imageVector =
-                        when (viewTypeLocal) {
+                        when (playlistViewType) {
                             LibraryViewType.LIST -> Icons.AutoMirrored.Rounded.List
                             LibraryViewType.GRID -> Icons.Rounded.GridView
                         },
@@ -226,16 +251,6 @@ fun LibraryPlaylistsScreen(
             } else {
                 Spacer(Modifier.size(16.dp))
             }
-        }
-    }
-
-    LaunchedEffect(scrollToTop?.value) {
-        if (scrollToTop?.value == true) {
-            when (viewType) {
-                LibraryViewType.LIST -> lazyListState.animateScrollToItem(0)
-                LibraryViewType.GRID -> lazyGridState.animateScrollToItem(0)
-            }
-            backStackEntry?.savedStateHandle?.set("scrollToTop", false)
         }
     }
 
@@ -252,7 +267,7 @@ fun LibraryPlaylistsScreen(
                         key = "filter",
                         contentType = CONTENT_TYPE_HEADER
                     ) {
-                        libraryFilterContent?.let { it() }
+                        libraryFilterContent?.let { it() } ?: filterContent()
                     }
 
                     item(
@@ -331,7 +346,7 @@ fun LibraryPlaylistsScreen(
                         span = { GridItemSpan(maxLineSpan) },
                         contentType = CONTENT_TYPE_HEADER
                     ) {
-                        libraryFilterContent?.let { it() }
+                        libraryFilterContent?.let { it() } ?: filterContent()
                     }
 
                     item(

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -61,6 +61,7 @@ import com.dd3boh.outertune.constants.PlaylistSortDescendingKey
 import com.dd3boh.outertune.constants.PlaylistSortType
 import com.dd3boh.outertune.constants.PlaylistSortTypeKey
 import com.dd3boh.outertune.constants.PlaylistViewTypeKey
+import com.dd3boh.outertune.constants.YtmSyncKey
 import com.dd3boh.outertune.db.entities.PlaylistEntity
 import com.dd3boh.outertune.ui.component.AutoPlaylistGridItem
 import com.dd3boh.outertune.ui.component.AutoPlaylistListItem
@@ -97,8 +98,7 @@ fun LibraryPlaylistsScreen(
 
     val (sortType, onSortTypeChange) = rememberEnumPreference(PlaylistSortTypeKey, PlaylistSortType.CREATE_DATE)
     val (sortDescending, onSortDescendingChange) = rememberPreference(PlaylistSortDescendingKey, true)
-
-    LaunchedEffect(Unit) { viewModel.sync() }
+    val (ytmSync) = rememberPreference(YtmSyncKey, true)
 
     val playlists by viewModel.allPlaylists.collectAsState()
 
@@ -116,6 +116,12 @@ fun LibraryPlaylistsScreen(
 
     var syncedPlaylist: Boolean by remember {
         mutableStateOf(false)
+    }
+
+    LaunchedEffect(Unit) {
+        if (ytmSync) {
+            viewModel.sync()
+        }
     }
 
     if (showAddPlaylistDialog) {

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryScreen.kt
@@ -105,6 +105,12 @@ fun LibraryScreen(
 
     val allItems by viewModel.allItems.collectAsState()
 
+    val isSyncingRemotePlaylists by viewModel.isSyncingRemotePlaylists.collectAsState()
+    val isSyncingRemoteAlbums by viewModel.isSyncingRemoteAlbums.collectAsState()
+    val isSyncingRemoteArtists by viewModel.isSyncingRemoteArtists.collectAsState()
+    val isSyncingRemoteSongs by viewModel.isSyncingRemoteSongs.collectAsState()
+    val isSyncingRemoteLikedSongs by viewModel.isSyncingRemoteLikedSongs.collectAsState()
+
     val likedPlaylist = PlaylistEntity(id = "liked", name = stringResource(id = R.string.liked_songs))
     val downloadedPlaylist = PlaylistEntity(id = "downloaded", name = stringResource(id = R.string.downloaded_songs))
 
@@ -201,7 +207,13 @@ fun LibraryScreen(
                         LibraryFilter.ALL
                 },
                 modifier = Modifier.weight(1f),
-                selected = { it == filterSelected }
+                selected = { it == filterSelected },
+                isLoading = { filter ->
+                    (filter == LibraryFilter.PLAYLISTS && isSyncingRemotePlaylists)
+                    || (filter == LibraryFilter.ALBUMS && isSyncingRemoteAlbums)
+                    || (filter == LibraryFilter.ARTISTS && isSyncingRemoteArtists)
+                    || (filter == LibraryFilter.SONGS && (isSyncingRemoteSongs || isSyncingRemoteLikedSongs))
+                }
             )
 
             if (filter != LibraryFilter.SONGS) {

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibrarySongsScreen.kt
@@ -90,11 +90,11 @@ fun LibrarySongsScreen(
     val (ytmSync) = rememberPreference(YtmSyncKey, true)
 
     val songs by viewModel.allSongs.collectAsState()
+    val isSyncingRemoteLikedSongs by viewModel.isSyncingRemoteLikedSongs.collectAsState()
+    val isSyncingRemoteSongs by viewModel.isSyncingRemoteSongs.collectAsState()
 
     val wrappedSongs = songs.map { item -> ItemWrapper(item) }.toMutableList()
-    var selection by remember {
-        mutableStateOf(false)
-    }
+    var selection by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         if (ytmSync) {
@@ -120,6 +120,9 @@ fun LibrarySongsScreen(
                     if (it == SongFilter.LIKED) viewModel.syncLikedSongs()
                     else if (it == SongFilter.LIBRARY) viewModel.syncLibrarySongs()
                 }
+            },
+            isLoading = { filter ->
+                (filter == SongFilter.LIKED && isSyncingRemoteLikedSongs) || (filter == SongFilter.LIBRARY && isSyncingRemoteSongs)
             }
         )
     }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -182,7 +182,7 @@ fun AutoPlaylistScreen(
 
     LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
-            if (playlistId == "liked") syncUtils.syncLikedSongs()
+            if (playlistId == "liked") syncUtils.syncRemoteLikedSongs()
         }
     }
 

--- a/app/src/main/java/com/dd3boh/outertune/utils/SyncUtils.kt
+++ b/app/src/main/java/com/dd3boh/outertune/utils/SyncUtils.kt
@@ -146,7 +146,7 @@ class SyncUtils @Inject constructor(
 
             // Inset or mark songs to library
             coroutineScope {
-                val jobs = remoteSongs.map { song ->
+                remoteSongs.forEach { song ->
                     launch(Dispatchers.IO) {
                         val dbSong = database.song(song.id).firstOrNull()
                         database.transaction {
@@ -158,7 +158,6 @@ class SyncUtils @Inject constructor(
                         }
                     }
                 }
-                jobs.joinAll()
             }
         } finally {
             Timber.tag(_TAG).d("Library songs synchronization ended")

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
@@ -97,12 +97,12 @@ class HomeViewModel @Inject constructor(
                 }
                 .distinctUntilChanged()
 
-            if (syncYtm.first() != false) { // defaults to true
-                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncLikedSongs() }
-                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncLibrarySongs() }
-                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncLibraryPlaylists() }
-                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncLibraryAlbums() }
-                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncArtistsSubscriptions() }
+            if (syncYtm.first() == true) { // defaults to true
+                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncRemoteLikedSongs() }
+                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncRemoteSongs() }
+                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncRemotePlaylists() }
+                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncRemoteAlbums() }
+                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncRemoteArtists() }
             }
         }
     }

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
@@ -97,7 +97,7 @@ class HomeViewModel @Inject constructor(
                 }
                 .distinctUntilChanged()
 
-            if (syncYtm.first() == true) { // defaults to true
+            if (syncYtm.first() != false) { // defaults to true
                 viewModelScope.launch(Dispatchers.IO) { syncUtils.syncRemoteLikedSongs() }
                 viewModelScope.launch(Dispatchers.IO) { syncUtils.syncRemoteSongs() }
                 viewModelScope.launch(Dispatchers.IO) { syncUtils.syncRemotePlaylists() }

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
@@ -100,8 +100,8 @@ class HomeViewModel @Inject constructor(
             if (syncYtm.first() != false) { // defaults to true
                 viewModelScope.launch(Dispatchers.IO) { syncUtils.syncLikedSongs() }
                 viewModelScope.launch(Dispatchers.IO) { syncUtils.syncLibrarySongs() }
-                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncSavedPlaylists() }
-                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncLikedAlbums() }
+                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncLibraryPlaylists() }
+                viewModelScope.launch(Dispatchers.IO) { syncUtils.syncLibraryAlbums() }
                 viewModelScope.launch(Dispatchers.IO) { syncUtils.syncArtistsSubscriptions() }
             }
         }

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/LibraryViewModels.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/LibraryViewModels.kt
@@ -3,7 +3,6 @@
 package com.dd3boh.outertune.viewmodels
 
 import android.content.Context
-import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -226,7 +225,7 @@ class LibraryAlbumsViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
-    fun sync() { viewModelScope.launch(Dispatchers.IO) { syncUtils.syncLikedAlbums() } }
+    fun sync() { viewModelScope.launch(Dispatchers.IO) { syncUtils.syncLibraryAlbums() } }
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
@@ -268,7 +267,7 @@ class LibraryPlaylistsViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
-    fun sync() { viewModelScope.launch(Dispatchers.IO) { syncUtils.syncSavedPlaylists() } }
+    fun sync() { viewModelScope.launch(Dispatchers.IO) { syncUtils.syncLibraryPlaylists() } }
 }
 
 @HiltViewModel

--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -465,15 +465,21 @@ object YouTube {
         )
     }
 
-    suspend fun library(browseId: String) = runCatching {
+    suspend fun library(browseId: String, tabIndex: Int = 0) = runCatching {
         val response = innerTube.browse(
             client = WEB_REMIX,
             browseId = browseId,
             setLogin = true
         ).body<BrowseResponse>()
 
-        val contents = response.contents?.singleColumnBrowseResultsRenderer?.tabs?.firstOrNull()?.
-        tabRenderer?.content?.sectionListRenderer?.contents?.firstOrNull()
+        val tabs = response.contents?.singleColumnBrowseResultsRenderer?.tabs
+
+        val contents = if (tabs != null && tabs.size >= tabIndex) {
+                tabs[tabIndex].tabRenderer.content?.sectionListRenderer?.contents?.firstOrNull()
+            }
+            else {
+                null
+            }
 
         when {
             contents?.gridRenderer != null -> {


### PR DESCRIPTION
- Include uploaded songs
- Make syncing of songs, albums, playlists, artist faster (corutines) and only allow one sync to run (singleton like)
- Show loading spinner in chip when syncing it
- Rename some functions
- Match selected header size to sort header
- Liked songs sort by creation or release date showed all library songs