### PR TITLE
Old view show extra playlists 

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -14,6 +14,7 @@ val EnabledTabsKey = stringPreferencesKey("enabledTabs")
 val DefaultOpenTabKey = stringPreferencesKey("defaultOpenTab")
 val DefaultOpenTabNewKey = stringPreferencesKey("defaultOpenTabNew")
 val NewInterfaceKey = booleanPreferencesKey("newInterface")
+val ShowLikedAndDownloadedPlaylist = booleanPreferencesKey("showLikedAndDownloadedPlaylist")
 
 const val SYSTEM_DEFAULT = "SYSTEM_DEFAULT"
 val ContentLanguageKey = stringPreferencesKey("contentLanguage")

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -61,6 +61,7 @@ import com.dd3boh.outertune.constants.PlaylistSortDescendingKey
 import com.dd3boh.outertune.constants.PlaylistSortType
 import com.dd3boh.outertune.constants.PlaylistSortTypeKey
 import com.dd3boh.outertune.constants.PlaylistViewTypeKey
+import com.dd3boh.outertune.constants.ShowLikedAndDownloadedPlaylist
 import com.dd3boh.outertune.db.entities.PlaylistEntity
 import com.dd3boh.outertune.ui.component.AutoPlaylistGridItem
 import com.dd3boh.outertune.ui.component.AutoPlaylistListItem
@@ -97,6 +98,7 @@ fun LibraryPlaylistsScreen(
 
     val (sortType, onSortTypeChange) = rememberEnumPreference(PlaylistSortTypeKey, PlaylistSortType.CREATE_DATE)
     val (sortDescending, onSortDescendingChange) = rememberPreference(PlaylistSortDescendingKey, true)
+    val (showLikedAndDownloadedPlaylist, _) = rememberPreference(ShowLikedAndDownloadedPlaylist, false)
 
     LaunchedEffect(Unit) { viewModel.sync() }
 
@@ -256,7 +258,7 @@ fun LibraryPlaylistsScreen(
                         headerContent()
                     }
 
-                    if (libraryFilterContent != null) {
+                    if (libraryFilterContent != null || showLikedAndDownloadedPlaylist) {
                         item(
                             key = likedPlaylist.id,
                             contentType = { CONTENT_TYPE_PLAYLIST }
@@ -336,7 +338,7 @@ fun LibraryPlaylistsScreen(
                         headerContent()
                     }
 
-                    if (libraryFilterContent != null) {
+                    if (libraryFilterContent != null || showLikedAndDownloadedPlaylist) {
                         item(
                             key = likedPlaylist.id,
                             contentType = { CONTENT_TYPE_PLAYLIST }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -98,7 +98,7 @@ fun LibraryPlaylistsScreen(
 
     val (sortType, onSortTypeChange) = rememberEnumPreference(PlaylistSortTypeKey, PlaylistSortType.CREATE_DATE)
     val (sortDescending, onSortDescendingChange) = rememberPreference(PlaylistSortDescendingKey, true)
-    val (showLikedAndDownloadedPlaylist, _) = rememberPreference(ShowLikedAndDownloadedPlaylist, false)
+    val (showLikedAndDownloadedPlaylist) = rememberPreference(ShowLikedAndDownloadedPlaylist, true)
 
     LaunchedEffect(Unit) { viewModel.sync() }
 
@@ -258,7 +258,7 @@ fun LibraryPlaylistsScreen(
                         headerContent()
                     }
 
-                    if (libraryFilterContent != null || showLikedAndDownloadedPlaylist) {
+                    if (showLikedAndDownloadedPlaylist) {
                         item(
                             key = likedPlaylist.id,
                             contentType = { CONTENT_TYPE_PLAYLIST }
@@ -338,7 +338,7 @@ fun LibraryPlaylistsScreen(
                         headerContent()
                     }
 
-                    if (libraryFilterContent != null || showLikedAndDownloadedPlaylist) {
+                    if (showLikedAndDownloadedPlaylist) {
                         item(
                             key = likedPlaylist.id,
                             contentType = { CONTENT_TYPE_PLAYLIST }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/library/LibraryScreen.kt
@@ -57,6 +57,7 @@ import com.dd3boh.outertune.constants.LibrarySortType
 import com.dd3boh.outertune.constants.LibrarySortTypeKey
 import com.dd3boh.outertune.constants.LibraryViewType
 import com.dd3boh.outertune.constants.LibraryViewTypeKey
+import com.dd3boh.outertune.constants.ShowLikedAndDownloadedPlaylist
 import com.dd3boh.outertune.db.entities.Album
 import com.dd3boh.outertune.db.entities.Artist
 import com.dd3boh.outertune.db.entities.Playlist
@@ -102,6 +103,7 @@ fun LibraryScreen(
 
     val (sortType, onSortTypeChange) = rememberEnumPreference(LibrarySortTypeKey, LibrarySortType.CREATE_DATE)
     val (sortDescending, onSortDescendingChange) = rememberPreference(LibrarySortDescendingKey, true)
+    val (showLikedAndDownloadedPlaylist) = rememberPreference(ShowLikedAndDownloadedPlaylist, true)
 
     val allItems by viewModel.allItems.collectAsState()
 
@@ -312,36 +314,38 @@ fun LibraryScreen(
                                 headerContent()
                             }
 
-                            item(
-                                key = likedPlaylist.id,
-                                contentType = { CONTENT_TYPE_PLAYLIST }
-                            ) {
-                                AutoPlaylistListItem(
-                                    playlist = likedPlaylist,
-                                    thumbnail = Icons.Rounded.Favorite,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .clickable {
-                                            navController.navigate("auto_playlist/${likedPlaylist.id}")
-                                        }
-                                        .animateItemPlacement()
-                                )
-                            }
+                            if (showLikedAndDownloadedPlaylist) {
+                                item(
+                                    key = likedPlaylist.id,
+                                    contentType = { CONTENT_TYPE_PLAYLIST }
+                                ) {
+                                    AutoPlaylistListItem(
+                                        playlist = likedPlaylist,
+                                        thumbnail = Icons.Rounded.Favorite,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .clickable {
+                                                navController.navigate("auto_playlist/${likedPlaylist.id}")
+                                            }
+                                            .animateItemPlacement()
+                                    )
+                                }
 
-                            item(
-                                key = downloadedPlaylist.id,
-                                contentType = { CONTENT_TYPE_PLAYLIST }
-                            ) {
-                                AutoPlaylistListItem(
-                                    playlist = downloadedPlaylist,
-                                    thumbnail = Icons.Rounded.CloudDownload,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .clickable {
-                                            navController.navigate("auto_playlist/${downloadedPlaylist.id}")
-                                        }
-                                        .animateItemPlacement()
-                                )
+                                item(
+                                    key = downloadedPlaylist.id,
+                                    contentType = { CONTENT_TYPE_PLAYLIST }
+                                ) {
+                                    AutoPlaylistListItem(
+                                        playlist = downloadedPlaylist,
+                                        thumbnail = Icons.Rounded.CloudDownload,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .clickable {
+                                                navController.navigate("auto_playlist/${downloadedPlaylist.id}")
+                                            }
+                                            .animateItemPlacement()
+                                    )
+                                }
                             }
 
                             items(
@@ -409,38 +413,40 @@ fun LibraryScreen(
                                 headerContent()
                             }
 
-                            item(
-                                key = likedPlaylist.id,
-                                contentType = { CONTENT_TYPE_PLAYLIST }
-                            ) {
-                                AutoPlaylistGridItem(
-                                    playlist = likedPlaylist,
-                                    thumbnail = Icons.Rounded.Favorite,
-                                    fillMaxWidth = true,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .clickable {
-                                            navController.navigate("auto_playlist/${likedPlaylist.id}")
-                                        }
-                                        .animateItemPlacement()
-                                )
-                            }
+                            if (showLikedAndDownloadedPlaylist) {
+                                item(
+                                    key = likedPlaylist.id,
+                                    contentType = { CONTENT_TYPE_PLAYLIST }
+                                ) {
+                                    AutoPlaylistGridItem(
+                                        playlist = likedPlaylist,
+                                        thumbnail = Icons.Rounded.Favorite,
+                                        fillMaxWidth = true,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .clickable {
+                                                navController.navigate("auto_playlist/${likedPlaylist.id}")
+                                            }
+                                            .animateItemPlacement()
+                                    )
+                                }
 
-                            item(
-                                key = downloadedPlaylist.id,
-                                contentType = { CONTENT_TYPE_PLAYLIST }
-                            ) {
-                                AutoPlaylistGridItem(
-                                    playlist = downloadedPlaylist,
-                                    thumbnail = Icons.Rounded.CloudDownload,
-                                    fillMaxWidth = true,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .clickable {
-                                            navController.navigate("auto_playlist/${downloadedPlaylist.id}")
-                                        }
-                                        .animateItemPlacement()
-                                )
+                                item(
+                                    key = downloadedPlaylist.id,
+                                    contentType = { CONTENT_TYPE_PLAYLIST }
+                                ) {
+                                    AutoPlaylistGridItem(
+                                        playlist = downloadedPlaylist,
+                                        thumbnail = Icons.Rounded.CloudDownload,
+                                        fillMaxWidth = true,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .clickable {
+                                                navController.navigate("auto_playlist/${downloadedPlaylist.id}")
+                                            }
+                                            .animateItemPlacement()
+                                    )
+                                }
                             }
 
                             items(

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/AppearanceSettings.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.PlaylistPlay
 import androidx.compose.material.icons.rounded.BlurOn
 import androidx.compose.material.icons.rounded.Contrast
 import androidx.compose.material.icons.rounded.DarkMode
@@ -103,7 +104,7 @@ fun AppearanceSettings(
     val (defaultOpenTab, onDefaultOpenTabChange) = rememberEnumPreference(DefaultOpenTabKey, defaultValue = NavigationTab.HOME)
     val (defaultOpenTabNew, onDefaultOpenTabNewChange) = rememberEnumPreference(DefaultOpenTabNewKey, defaultValue = NavigationTabNew.HOME)
     val (newInterfaceStyle, onNewInterfaceStyleChange) = rememberPreference(key = NewInterfaceKey, defaultValue = true)
-    val (showLikedAndDownloadedPlaylist, onShowLikedAndDownloadedPlaylistChange) = rememberPreference(key = ShowLikedAndDownloadedPlaylist, defaultValue = false)
+    val (showLikedAndDownloadedPlaylist, onShowLikedAndDownloadedPlaylistChange) = rememberPreference(key = ShowLikedAndDownloadedPlaylist, defaultValue = true)
     val (flatSubfolders, onFlatSubfoldersChange) = rememberPreference(FlatSubfoldersKey, defaultValue = true)
 
     val availableBackgroundStyles = PlayerBackgroundStyle.entries.filter {
@@ -196,14 +197,12 @@ fun AppearanceSettings(
             onCheckedChange = onNewInterfaceStyleChange
         )
 
-        if (!newInterfaceStyle){
-            SwitchPreference(
-                title = { Text(stringResource(R.string.show_liked_and_downloaded_playlist)) },
-                icon = { Icon(Icons.Rounded.PlaylistPlay, null) },
-                checked = showLikedAndDownloadedPlaylist,
-                onCheckedChange = onShowLikedAndDownloadedPlaylistChange
-            )
-        }
+        SwitchPreference(
+            title = { Text(stringResource(R.string.show_liked_and_downloaded_playlist)) },
+            icon = { Icon(Icons.AutoMirrored.Rounded.PlaylistPlay, null) },
+            checked = showLikedAndDownloadedPlaylist,
+            onCheckedChange = onShowLikedAndDownloadedPlaylistChange
+        )
 
         PreferenceEntry(
             title = { Text("Tab arrangement") },

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/AppearanceSettings.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.rounded.DarkMode
 import androidx.compose.material.icons.rounded.DragHandle
 import androidx.compose.material.icons.rounded.FolderCopy
 import androidx.compose.material.icons.rounded.Palette
+import androidx.compose.material.icons.rounded.PlaylistPlay
 import androidx.compose.material.icons.rounded.Reorder
 import androidx.compose.material.icons.rounded.Tab
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -53,6 +54,7 @@ import com.dd3boh.outertune.constants.FlatSubfoldersKey
 import com.dd3boh.outertune.constants.NewInterfaceKey
 import com.dd3boh.outertune.constants.PlayerBackgroundStyleKey
 import com.dd3boh.outertune.constants.PureBlackKey
+import com.dd3boh.outertune.constants.ShowLikedAndDownloadedPlaylist
 import com.dd3boh.outertune.constants.ThumbnailCornerRadius
 import com.dd3boh.outertune.extensions.move
 import com.dd3boh.outertune.ui.component.ActionPromptDialog
@@ -101,6 +103,7 @@ fun AppearanceSettings(
     val (defaultOpenTab, onDefaultOpenTabChange) = rememberEnumPreference(DefaultOpenTabKey, defaultValue = NavigationTab.HOME)
     val (defaultOpenTabNew, onDefaultOpenTabNewChange) = rememberEnumPreference(DefaultOpenTabNewKey, defaultValue = NavigationTabNew.HOME)
     val (newInterfaceStyle, onNewInterfaceStyleChange) = rememberPreference(key = NewInterfaceKey, defaultValue = true)
+    val (showLikedAndDownloadedPlaylist, onShowLikedAndDownloadedPlaylistChange) = rememberPreference(key = ShowLikedAndDownloadedPlaylist, defaultValue = false)
     val (flatSubfolders, onFlatSubfoldersChange) = rememberPreference(FlatSubfoldersKey, defaultValue = true)
 
     val availableBackgroundStyles = PlayerBackgroundStyle.entries.filter {
@@ -192,6 +195,15 @@ fun AppearanceSettings(
             checked = newInterfaceStyle,
             onCheckedChange = onNewInterfaceStyleChange
         )
+
+        if (!newInterfaceStyle){
+            SwitchPreference(
+                title = { Text(stringResource(R.string.show_liked_and_downloaded_playlist)) },
+                icon = { Icon(Icons.Rounded.PlaylistPlay, null) },
+                checked = showLikedAndDownloadedPlaylist,
+                onCheckedChange = onShowLikedAndDownloadedPlaylistChange
+            )
+        }
 
         PreferenceEntry(
             title = { Text("Tab arrangement") },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,6 +346,7 @@
     <string name="player_background_gradient">Gradient</string>
     <string name="player_background_blur">Blur</string>
     <string name="new_interface">New interface layout</string>
+    <string name="show_liked_and_downloaded_playlist">Show liked and downloaded playlist</string>">
 
     <!-- Content settings -->
     <string name="ytm_sync">Automatically sync with your YouTube Music account</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,7 +346,7 @@
     <string name="player_background_gradient">Gradient</string>
     <string name="player_background_blur">Blur</string>
     <string name="new_interface">New interface layout</string>
-    <string name="show_liked_and_downloaded_playlist">Show liked and downloaded playlist</string>">
+    <string name="show_liked_and_downloaded_playlist">Show liked and downloaded playlists in library</string>">
 
     <!-- Content settings -->
     <string name="ytm_sync">Automatically sync with your YouTube Music account</string>


### PR DESCRIPTION
add an appearance option to enable showing the liked and downloaded playlists in old layout

<p><strong>Show Off vs ON</strong></p>
<img src="https://github.com/user-attachments/assets/cd7f6906-0e1b-4b93-95b0-11b93a0cd22c" width="200"/>
<img src="https://github.com/user-attachments/assets/5f9f459d-d196-4504-a9c3-897397bc9e62" width="200"/>
<p><strong>Setting toggle</strong></p>
<img src="https://github.com/user-attachments/assets/6c93c6cb-eb31-4a11-8c80-42a8f9982467" width="200"/>
<img src="https://github.com/user-attachments/assets/bdfc7706-aeb0-45b9-8228-786a1d22f7b8" width="200"/>
