### PR TITLE
fix miniplayer transition

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/ui/component/BottomSheet.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/BottomSheet.kt
@@ -108,7 +108,7 @@ fun BottomSheet(
                 modifier = Modifier
                     .fillMaxSize()
                     .graphicsLayer {
-                        alpha = ((state.progress - 0.25f) * 4).coerceIn(0f, 1f)
+                        alpha = ((state.progress * 4 - 0.25f) * 4).coerceIn(0f, 1f)
                     }
                     .background(backgroundColor),
                 content = content

--- a/app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/player/Player.kt
@@ -226,7 +226,7 @@ fun BottomSheetPlayer(
         backgroundColor = if (useDarkTheme || playerBackground == PlayerBackgroundStyle.DEFAULT) {
             MaterialTheme.colorScheme.surfaceColorAtElevation(NavigationBarDefaults.Elevation)
         } else MaterialTheme.colorScheme.onSurfaceVariant,
-        collapsedBackgroundColor = MaterialTheme.colorScheme.surfaceColorAtElevation(NavigationBarDefaults.Elevation),
+        collapsedBackgroundColor = Color.Transparent,
         onDismiss = {
             playerConnection.player.stop()
             playerConnection.player.clearMediaItems()


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Translations
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other
<!-- If you selected Translations, please this pull request only contains translations changes, and NO code changes (unless it is absolutely necessary, please provide a description of why). Please ensure your are able to build and run the app. You can simply delete the next 4 sections as they do not apply. -->

#### Fixes the following issue(s)
- while pulling the mini player up makes the transition better


#### Due diligence
<!-- Please mark WIP pull requests and "Draft" and only "Ready for review" once it is ready to be merged  -->
- [ ] I read the [contribution guidelines](https://github.com/DD3Boh/OuterTune/blob/dev/CONTRIBUTING.md).
- [ ] I understand that in the event of merge conflicts, **I may be asked to rebase my branch** on top of the dev branch, instead of resolving them by merging dev into my own branch


<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->