### PR TITLE
Possible fix for Starting song radio from queue creates a queue based on the wrong song #263

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -49,6 +49,7 @@ val PersistentQueueKey = booleanPreferencesKey("persistentQueue")
 val SkipSilenceKey = booleanPreferencesKey("skipSilence")
 val SkipOnErrorKey = booleanPreferencesKey("skipOnError")
 val AudioNormalizationKey = booleanPreferencesKey("audioNormalization")
+val AutoLoadMoreKey = booleanPreferencesKey("autoLoadMore")
 val KeepAliveKey = booleanPreferencesKey("keepAlive")
 val StopMusicOnTaskClearKey = booleanPreferencesKey("stopMusicOnTaskClear")
 

--- a/app/src/main/java/com/dd3boh/outertune/db/DatabaseDao.kt
+++ b/app/src/main/java/com/dd3boh/outertune/db/DatabaseDao.kt
@@ -304,7 +304,8 @@ interface DatabaseDao : SongsDao, AlbumsDao, ArtistsDao, PlaylistsDao, QueueDao 
                 title = mq.title,
                 shuffled = mq.shuffled,
                 queuePos = mq.queuePos,
-                index = mq.index
+                index = mq.index,
+                playlistId = mq.playlistId
             )
         )
 

--- a/app/src/main/java/com/dd3boh/outertune/db/daos/QueueDao.kt
+++ b/app/src/main/java/com/dd3boh/outertune/db/daos/QueueDao.kt
@@ -55,7 +55,8 @@ interface QueueDao {
                     unShuffled = unshuffledSongs.map { it.toMediaMetadata() }.toMutableList(),
                     shuffled = queue.shuffled,
                     queuePos = queue.queuePos,
-                    index = queue.index
+                    index = queue.index,
+                    playlistId = queue.playlistId
                 )
             )
         }

--- a/app/src/main/java/com/dd3boh/outertune/models/QueueBoard.kt
+++ b/app/src/main/java/com/dd3boh/outertune/models/QueueBoard.kt
@@ -1,10 +1,9 @@
 package com.dd3boh.outertune.models
 
 import androidx.media3.common.C
-import androidx.media3.common.MediaItem
 import com.dd3boh.outertune.constants.PersistentQueueKey
 import com.dd3boh.outertune.db.entities.QueueEntity
-import com.dd3boh.outertune.extensions.metadata
+import com.dd3boh.outertune.extensions.currentMetadata
 import com.dd3boh.outertune.extensions.move
 import com.dd3boh.outertune.extensions.toMediaItem
 import com.dd3boh.outertune.playback.MusicService
@@ -335,7 +334,7 @@ class QueueBoard(queues: MutableList<MultiQueueObject> = ArrayList()) {
      */
     fun enqueueEnd(mediaList: List<MediaMetadata>, player: MusicService) {
         getCurrentQueue()?.let {
-            addSongsToQueue(it, Int.MAX_VALUE, mediaList, player)
+            addSongsToQueue(it, Int.MAX_VALUE, mediaList, player, isRadio)
         }
     }
 
@@ -352,7 +351,7 @@ class QueueBoard(queues: MutableList<MultiQueueObject> = ArrayList()) {
         val listPos = if (pos < 0) {
             0
         } else if (pos > q.queue.size) {
-            q.queue.size - 1
+            q.queue.size
         } else {
             pos
         }
@@ -360,18 +359,23 @@ class QueueBoard(queues: MutableList<MultiQueueObject> = ArrayList()) {
         // Add to current queue at the position. For the other queue, just add to end
         if (q.shuffled) {
             q.queue.addAll(listPos, mediaList)
-            q.unShuffled.addAll(q.queue.size - 1, mediaList)
+            q.unShuffled.addAll(q.queue.size, mediaList)
         } else {
-            q.queue.addAll(q.queue.size - 1, mediaList)
+            q.queue.addAll(q.queue.size, mediaList)
             q.unShuffled.addAll(listPos, mediaList)
         }
 
-        // copy so ui doesnt crash
-        player.player.replaceMediaItems(listPos, pos, mediaList.map { it.toMediaItem() })
+        setCurrQueue(q, player)
+
+        val newQ = if (isRadio) {
+            q.copy(playlistId = mediaList.lastOrNull()?.id)
+        } else {
+            q
+        }
 
         if (saveToDb && player.dataStore.get(PersistentQueueKey, true)) {
             CoroutineScope(Dispatchers.IO).launch {
-                player.database.rewriteQueue(q)
+                player.database.rewriteQueue(newQ)
             }
         }
     }
@@ -698,7 +702,7 @@ class QueueBoard(queues: MutableList<MultiQueueObject> = ArrayList()) {
             )
 
         if (item == null) {
-            setMediaItems(ArrayList(), player)
+            player.player.setMediaItems(ArrayList())
             return null
         }
 
@@ -712,54 +716,44 @@ class QueueBoard(queues: MutableList<MultiQueueObject> = ArrayList()) {
         } else {
             mediaItems = item.unShuffled
         }
-        setMediaItems(mediaItems, player)
+
+        /**
+         * current playing == jump target, do seamlessly
+         */
+        val seamlessSupported = player.player.currentMetadata?.id == mediaItems[queuePos].id
+        if (seamlessSupported) {
+            if (queuePos == 0) {
+                val playerIndex = player.player.currentMediaItemIndex
+                val playerItemCount = player.player.mediaItemCount
+                // player.player.replaceMediaItems seems to stop playback so we
+                // remove all songs except the currently playing one and then add the list of new items
+                if (playerIndex < playerItemCount - 1) {
+                    player.player.removeMediaItems(playerIndex + 1, playerItemCount)
+                }
+                if (playerIndex > 0) {
+                    player.player.removeMediaItems(0, playerIndex)
+                }
+                // add all songs except the first one since it is already present and playing
+                player.player.addMediaItems(mediaItems.drop(1).map { it.toMediaItem() })
+            } else {
+                // replace items up to current playing, then replace items after current
+                player.player.replaceMediaItems(0, queuePos,
+                    mediaItems.subList(0, queuePos).map { it.toMediaItem() })
+                player.player.replaceMediaItems(queuePos + 1, Int.MAX_VALUE,
+                    mediaItems.subList(queuePos + 1, mediaItems.size).map { it.toMediaItem() })
+            }
+        } else {
+            player.player.setMediaItems(mediaItems.map { it.toMediaItem() })
+        }
+
         isShuffleEnabled.value = item.shuffled
 
-        if (autoSeek && !allowSeamlessPlayback(player, mediaItems)) {
+        if (autoSeek && !seamlessSupported) {
             player.player.seekTo(queuePos, C.TIME_UNSET)
         }
 
         bubbleUp(item, player)
         return queuePos
-    }
-
-    /**
-     * Test if playback can be switched seamlessly
-     * return true if player is playing the first song of the new media items
-     */
-    private fun allowSeamlessPlayback(
-        player: MusicService,
-        mediaItems: List<MediaMetadata>
-    ): Boolean {
-        if (!player.player.isPlaying) {
-            return false
-        }
-        val currentSongId = player.currentMediaMetadata.value?.id ?: return false
-        return mediaItems.firstOrNull()?.id.equals(currentSongId)
-    }
-
-    /**
-     * Sets the media items. If the first media item matches the currently playing song it will
-     * switches to the new list of items without interrupting playback otherwise it replaces the
-     * media items
-     */
-    private fun setMediaItems(mediaItems: List<MediaMetadata>, player: MusicService) {
-        if (allowSeamlessPlayback(player, mediaItems)) {
-            // player.player.replaceMediaItems seems to stop playback so we
-            // remove all songs except the currently playing one and then add the list of new items
-            if (player.player.currentMediaItemIndex > 0) player.player.removeMediaItems(
-                0,
-                player.player.currentMediaItemIndex
-            )
-            if (player.player.currentMediaItemIndex < player.player.mediaItemCount - 1) player.player.removeMediaItems(
-                player.player.currentMediaItemIndex + 1,
-                player.player.mediaItemCount
-            )
-            // add all songs except the first one since it is already present and playing
-            player.player.addMediaItems(mediaItems.drop(1).map { it.toMediaItem() })
-        } else {
-            player.player.setMediaItems(mediaItems.map { it.toMediaItem() })
-        }
     }
 
     /**
@@ -776,30 +770,6 @@ class QueueBoard(queues: MutableList<MultiQueueObject> = ArrayList()) {
                         player.database.updateQueue(it)
                     }
                 }
-            }
-        }
-    }
-
-    /**
-     * Update the current position index of the current queue to the index of the FIRST media item match
-     *
-     * @param mediaItem
-     */
-    fun setCurrQueuePosIndex(mediaItem: MediaItem?, player: MusicService) {
-        val currentQueue = getCurrentQueue()
-        if (mediaItem == null || currentQueue == null) {
-            return
-        }
-
-        if (currentQueue.shuffled) {
-            currentQueue.queuePos = currentQueue.queue.indexOf(mediaItem.metadata)
-        } else {
-            currentQueue.queuePos = currentQueue.unShuffled.indexOf(mediaItem.metadata)
-        }
-
-        if (player.dataStore.get(PersistentQueueKey, true)) {
-            CoroutineScope(Dispatchers.IO).launch {
-                player.database.updateQueue(currentQueue)
             }
         }
     }

--- a/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
@@ -581,17 +581,25 @@ class MusicService : MediaLibraryService(),
             if (queueTitle == null && initialStatus.title != null) { // do not find a title if an override is provided
                 queueTitle = initialStatus.title
             }
+            val items = ArrayList<MediaMetadata>()
+            val preloadItem = queue.preloadItem
 
             // print out queue
 //            println("-----------------------------")
 //            initialStatus.items.map { println(it.title) }
             if (initialStatus.items.isEmpty()) return@launch
+            if (preloadItem != null) {
+                items.add(preloadItem)
+                items.addAll(initialStatus.items.subList(1, initialStatus.items.size))
+            } else {
+                items.addAll(initialStatus.items)
+            }
             queueBoard.addQueue(
                 queueTitle?: "Queue",
-                initialStatus.items,
+                items,
                 player = this@MusicService,
                 startIndex = if (initialStatus.mediaItemIndex > 0) initialStatus.mediaItemIndex else 0,
-                replace = replace
+                replace = replace,
             )
             queueBoard.setCurrQueue(this@MusicService)
 
@@ -604,12 +612,10 @@ class MusicService : MediaLibraryService(),
      * Add items to queue, right after current playing item
      */
     fun enqueueNext(items: List<MediaItem>) {
-        println("wtf "+ "ENQUEUNE NEXT CALLED " + queueBoard.initialized)
         if (!queueBoard.initialized) {
 
             // when enqueuing next when player isn't active, play as a new song
             if (items.isNotEmpty()) {
-                println("wtf "+ "PLAYING FROMe")
                 CoroutineScope(Dispatchers.Main).launch {
                     playQueue(
                         ListQueue(

--- a/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
@@ -62,6 +62,7 @@ import com.dd3boh.outertune.constants.AudioNormalizationKey
 import com.dd3boh.outertune.constants.AudioOffload
 import com.dd3boh.outertune.constants.AudioQuality
 import com.dd3boh.outertune.constants.AudioQualityKey
+import com.dd3boh.outertune.constants.AutoLoadMoreKey
 import com.dd3boh.outertune.constants.KeepAliveKey
 import com.dd3boh.outertune.constants.LastPosKey
 import com.dd3boh.outertune.constants.MediaSessionConstants.CommandToggleLike
@@ -91,6 +92,7 @@ import com.dd3boh.outertune.extensions.metadata
 import com.dd3boh.outertune.extensions.setOffloadEnabled
 import com.dd3boh.outertune.extensions.toMediaItem
 import com.dd3boh.outertune.lyrics.LyricsHelper
+import com.dd3boh.outertune.models.MediaMetadata
 import com.dd3boh.outertune.models.QueueBoard
 import com.dd3boh.outertune.models.isShuffleEnabled
 import com.dd3boh.outertune.models.toMediaMetadata
@@ -137,6 +139,7 @@ import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.time.LocalDateTime
 import javax.inject.Inject
+import kotlin.collections.map
 import kotlin.math.min
 import kotlin.math.pow
 
@@ -279,6 +282,22 @@ class MusicService : MediaLibraryService(),
                             player.play()
                         }
 
+                        // Auto load more songs
+                        val q = queueBoard.getCurrentQueue()
+                        val songId = q?.playlistId
+                        if (dataStore.get(AutoLoadMoreKey, true) &&
+                            reason != Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT &&
+                            player.mediaItemCount - player.currentMediaItemIndex <= 5 &&
+                            songId != null // aka "hasNext"
+                        ) {
+                            scope.launch(SilentHandler) {
+                                val mediaItems = YouTubeQueue(WatchEndpoint(songId)).nextPage()
+                                if (player.playbackState != STATE_IDLE) {
+                                    queueBoard.enqueueEnd(mediaItems, this@MusicService, isRadio = true)
+                                }
+                            }
+                        }
+
                         // this absolute eye sore detects if we loop back to the beginning of queue, when shuffle AND repeat all
                         // no, when repeat mode is on, player does not "STATE_ENDED"
                         if (player.currentMediaItemIndex == 0 && lastMediaItemIndex == player.mediaItemCount - 1 &&
@@ -292,7 +311,7 @@ class MusicService : MediaLibraryService(),
                         updateNotification() // also updates when queue changes
 
                         queueBoard.setCurrQueuePosIndex(player.currentMediaItemIndex, this@MusicService)
-                        queueTitle = queueBoard.getCurrentQueue()?.title
+                        queueTitle = q?.title
                     }
                 })
                 sleepTimer = SleepTimer(scope, this)
@@ -568,7 +587,13 @@ class MusicService : MediaLibraryService(),
      * @param title Title override for the queue. If this value us unspecified, this method takes the value from queue.
      * If both are unspecified, the title will default to "Queue".
      */
-    fun playQueue(queue: Queue, playWhenReady: Boolean = true, replace: Boolean = false, title: String? = null) {
+    fun playQueue(
+        queue: Queue,
+        playWhenReady: Boolean = true,
+        replace: Boolean = false,
+        isRadio: Boolean = false,
+        title: String? = null
+    ) {
         if (!queueBoard.initialized) {
             initQueue()
             queueBoard.initialized = true
@@ -600,6 +625,7 @@ class MusicService : MediaLibraryService(),
                 player = this@MusicService,
                 startIndex = if (initialStatus.mediaItemIndex > 0) initialStatus.mediaItemIndex else 0,
                 replace = replace,
+                isRadio = isRadio
             )
             queueBoard.setCurrQueue(this@MusicService)
 
@@ -661,7 +687,7 @@ class MusicService : MediaLibraryService(),
 
     fun toggleStartRadio() {
         val mediaMetadata = player.currentMetadata ?: return
-        playQueue(YouTubeQueue.radio(mediaMetadata))
+        playQueue(YouTubeQueue.radio(mediaMetadata), isRadio = true)
     }
 
     private fun openAudioEffectSession() {

--- a/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
@@ -293,7 +293,7 @@ class MusicService : MediaLibraryService(),
                             scope.launch(SilentHandler) {
                                 val mediaItems = YouTubeQueue(WatchEndpoint(songId)).nextPage()
                                 if (player.playbackState != STATE_IDLE) {
-                                    queueBoard.enqueueEnd(mediaItems, this@MusicService, isRadio = true)
+                                    queueBoard.enqueueEnd(mediaItems.drop(1), this@MusicService, isRadio = true)
                                 }
                             }
                         }

--- a/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MusicService.kt
@@ -600,20 +600,6 @@ class MusicService : MediaLibraryService(),
         }
     }
 
-    fun startRadioSeamlessly() {
-        val currentMediaMetadata = player.currentMetadata ?: return
-        if (player.currentMediaItemIndex > 0) player.removeMediaItems(0, player.currentMediaItemIndex)
-        if (player.currentMediaItemIndex < player.mediaItemCount - 1) player.removeMediaItems(player.currentMediaItemIndex + 1, player.mediaItemCount)
-        scope.launch(SilentHandler) {
-            val radioQueue = YouTubeQueue(endpoint = WatchEndpoint(videoId = currentMediaMetadata.id))
-            val initialStatus = radioQueue.getInitialStatus()
-            if (initialStatus.title != null) {
-                queueTitle = initialStatus.title
-            }
-            player.addMediaItems(initialStatus.items.drop(1).map { it.toMediaItem() })
-        }
-    }
-
     /**
      * Add items to queue, right after current playing item
      */
@@ -668,7 +654,8 @@ class MusicService : MediaLibraryService(),
     }
 
     fun toggleStartRadio() {
-        startRadioSeamlessly()
+        val mediaMetadata = player.currentMetadata ?: return
+        playQueue(YouTubeQueue.radio(mediaMetadata))
     }
 
     private fun openAudioEffectSession() {

--- a/app/src/main/java/com/dd3boh/outertune/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/PlayerConnection.kt
@@ -95,8 +95,8 @@ class PlayerConnection(
         repeatMode.value = player.repeatMode
     }
 
-    fun playQueue(queue: Queue, replace: Boolean = true, title: String? = null) {
-        service.playQueue(queue, replace = replace, title = title)
+    fun playQueue(queue: Queue, replace: Boolean = true, isRadio: Boolean = false, title: String? = null) {
+        service.playQueue(queue, replace = replace, title = title, isRadio = isRadio)
     }
 
     /**

--- a/app/src/main/java/com/dd3boh/outertune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/menu/PlayerMenu.kt
@@ -336,7 +336,7 @@ fun PlayerMenu(
                 icon = Icons.Rounded.Radio,
                 title = R.string.start_radio
             ) {
-                playerConnection.playQueue(YouTubeQueue.radio(mediaMetadata))
+                playerConnection.playQueue(YouTubeQueue.radio(mediaMetadata), isRadio = true)
                 onDismiss()
             }
         GridMenuItem(

--- a/app/src/main/java/com/dd3boh/outertune/ui/menu/PlaylistMenu.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/menu/PlaylistMenu.kt
@@ -331,7 +331,7 @@ fun PlaylistMenu(
                         playerConnection.playQueue(YouTubeQueue(WatchEndpoint(
                             playlistId = "RDAMPL$browseId",
                             params = radioEndpointParams,
-                        )))
+                        )), isRadio = true)
                         onDismiss()
                     }
                 }

--- a/app/src/main/java/com/dd3boh/outertune/ui/menu/SongMenu.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/menu/SongMenu.kt
@@ -277,7 +277,7 @@ fun SongMenu(
                 title = R.string.start_radio
             ) {
                 onDismiss()
-                playerConnection.playQueue(YouTubeQueue.radio(song.toMediaMetadata()))
+                playerConnection.playQueue(YouTubeQueue.radio(song.toMediaMetadata()), isRadio = true)
             }
         GridMenuItem(
             icon = Icons.AutoMirrored.Rounded.PlaylistPlay,

--- a/app/src/main/java/com/dd3boh/outertune/ui/menu/YouTubeArtistMenu.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/menu/YouTubeArtistMenu.kt
@@ -87,7 +87,7 @@ fun YouTubeArtistMenu(
                 icon = Icons.Rounded.Radio,
                 title = R.string.start_radio
             ) {
-                playerConnection.playQueue(YouTubeQueue(watchEndpoint))
+                playerConnection.playQueue(YouTubeQueue(watchEndpoint), isRadio = true)
                 onDismiss()
             }
         }
@@ -96,7 +96,7 @@ fun YouTubeArtistMenu(
                 icon = Icons.Rounded.Shuffle,
                 title = R.string.shuffle
             ) {
-                playerConnection.playQueue(YouTubeQueue(watchEndpoint))
+                playerConnection.playQueue(YouTubeQueue(watchEndpoint), isRadio = true)
                 onDismiss()
             }
         }

--- a/app/src/main/java/com/dd3boh/outertune/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/menu/YouTubePlaylistMenu.kt
@@ -334,7 +334,7 @@ fun YouTubePlaylistMenu(
                 title = R.string.start_radio
             ) {
                 println("Radio: ${radioEndpoint.playlistId}, ${radioEndpoint.params}")
-                playerConnection.playQueue(YouTubeQueue(radioEndpoint))
+                playerConnection.playQueue(YouTubeQueue(radioEndpoint), isRadio = true)
                 onDismiss()
             }
         }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
@@ -828,11 +828,11 @@ fun HomeScreen(
                         is SongItem -> playerConnection.playQueue(YouTubeQueue.radio(luckyItem.toMediaMetadata()))
                         is AlbumItem -> playerConnection.playQueue(YouTubeAlbumRadio(luckyItem.playlistId))
                         is ArtistItem -> luckyItem.radioEndpoint?.let {
-                            playerConnection.playQueue(YouTubeQueue(it))
+                            playerConnection.playQueue(YouTubeQueue(it), isRadio = true)
                         }
 
                         is PlaylistItem -> luckyItem.playEndpoint?.let {
-                            playerConnection.playQueue(YouTubeQueue(it))
+                            playerConnection.playQueue(YouTubeQueue(it), isRadio = true)
                         }
                     }
                 }

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/artist/ArtistScreen.kt
@@ -217,6 +217,7 @@ fun ArtistScreen(
                                     title = artistName,
                                     items = librarySongsAvailable().shuffled(),
                                 ),
+                                isRadio = true,
                                 title = artistName
                             )
                         },
@@ -240,6 +241,7 @@ fun ArtistScreen(
                                 onClick = {
                                     playerConnection.playQueue(
                                         YouTubeQueue(radioEndpoint),
+                                        isRadio = true,
                                         title = "Radio: ${artistPage.artist.title}"
                                     )
                                 },

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/PlayerSettings.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.automirrored.rounded.VolumeUp
+import androidx.compose.material.icons.rounded.Autorenew
 import androidx.compose.material.icons.rounded.Bolt
 import androidx.compose.material.icons.rounded.ClearAll
 import androidx.compose.material.icons.rounded.FastForward
@@ -35,6 +36,7 @@ import com.dd3boh.outertune.constants.AudioNormalizationKey
 import com.dd3boh.outertune.constants.AudioOffload
 import com.dd3boh.outertune.constants.AudioQuality
 import com.dd3boh.outertune.constants.AudioQualityKey
+import com.dd3boh.outertune.constants.AutoLoadMoreKey
 import com.dd3boh.outertune.constants.KeepAliveKey
 import com.dd3boh.outertune.constants.PersistentQueueKey
 import com.dd3boh.outertune.constants.SkipOnErrorKey
@@ -62,6 +64,7 @@ fun PlayerSettings(
     val (skipSilence, onSkipSilenceChange) = rememberPreference(key = SkipSilenceKey, defaultValue = false)
     val (skipOnErrorKey, onSkipOnErrorChange) = rememberPreference(key = SkipOnErrorKey, defaultValue = true)
     val (audioNormalization, onAudioNormalizationChange) = rememberPreference(key = AudioNormalizationKey, defaultValue = true)
+    val (autoLoadMore, onAutoLoadMoreChange) = rememberPreference(AutoLoadMoreKey, defaultValue = true)
     val (stopMusicOnTaskClear, onStopMusicOnTaskClearChange) = rememberPreference(key = StopMusicOnTaskClearKey, defaultValue = false)
     val (minPlaybackDur, onMinPlaybackDurChange) = rememberPreference(minPlaybackDurKey, defaultValue = 30)
     val (audioOffload, onAudioOffloadChange) = rememberPreference(key = AudioOffload, defaultValue = false)
@@ -96,7 +99,7 @@ fun PlayerSettings(
             .verticalScroll(rememberScrollState())
     ) {
         PreferenceGroupTitle(
-            title = stringResource(R.string.grp_layout)
+            title = stringResource(R.string.grp_general)
         )
         SwitchPreference(
             title = { Text(stringResource(R.string.persistent_queue)) },
@@ -104,6 +107,13 @@ fun PlayerSettings(
             icon = { Icon(Icons.AutoMirrored.Rounded.QueueMusic, null) },
             checked = persistentQueue,
             onCheckedChange = onPersistentQueueChange
+        )
+        SwitchPreference(
+            title = { Text(stringResource(R.string.auto_load_more)) },
+            description = stringResource(R.string.auto_load_more_desc),
+            icon = { Icon(Icons.Rounded.Autorenew, null) },
+            checked = autoLoadMore,
+            onCheckedChange = onAutoLoadMoreChange
         )
         // lyrics settings
         PreferenceEntry(

--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -57,6 +57,7 @@
 
 	<string name="grp_audio">Audio</string>
     <string name="grp_extra_scanner_settings">Additional scanner settings</string>
+    <string name="grp_general">General</string>
     <string name="grp_interface">Interface</string>
     <string name="grp_layout">Layout</string>
 	<string name="grp_localization">Localization</string>


### PR DESCRIPTION
#### What is it?
- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

#### Description of the changes in your PR
This is a possible fix for #263. 

However:
It would probably be better to call startRadioSeamlessly with mediaMetadata as parameter and handling the logic of selecting the right songs in there. 

Also adding another method in queueBoard to handle adding the songs and start it without interrupting the currently playing song would probably be cleaner than calling queueBoard.addQueue / queueBoard.setCurrQueuePosIndex.

I didn't want to start modifying too many things and let you use this code as a base to fix the issue