### PR TITLE
Unify font size of list items and grid items

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/ui/component/Items.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/Items.kt
@@ -79,7 +79,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastForEachIndexed
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.Download.STATE_COMPLETED
@@ -210,7 +209,7 @@ inline fun ListItem(
         ) {
             Text(
                 text = title,
-                fontSize = 14.sp,
+                style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Bold,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
@@ -255,7 +254,7 @@ fun ListItem(
             Text(
                 text = subtitle,
                 color = MaterialTheme.colorScheme.secondary,
-                fontSize = 12.sp,
+                style = MaterialTheme.typography.bodySmall,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
@@ -327,7 +326,7 @@ fun GridItem(
     title = {
         Text(
             text = title,
-            style = MaterialTheme.typography.bodyLarge,
+            style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
@@ -342,7 +341,7 @@ fun GridItem(
 
         Text(
             text = subtitle,
-            style = MaterialTheme.typography.bodyMedium,
+            style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.secondary,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
@@ -1250,7 +1249,7 @@ fun YouTubeGridItem(
     title = {
         Text(
             text = item.title,
-            style = MaterialTheme.typography.bodyLarge,
+            style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

#### Description of the changes in your PR
Unify font sizes of grid items and list items. Currently the font of the grid items is larger than the one from the list items. I think it would look better if they have the same font size

#### Before/After Screenshots/Screen Record
![Screenshot from 2025-01-28 22-59-57](https://github.com/user-attachments/assets/3baf8204-40ce-46ef-8364-ef3a774ee6b9)


#### Due diligence
<!-- Please mark WIP pull requests and "Draft" and only "Ready for review" once it is ready to be merged  -->
- [x] I read the [contribution guidelines](https://github.com/DD3Boh/OuterTune/blob/dev/CONTRIBUTING.md).
- [x] I understand that in the event of merge conflicts, **I may be asked to rebase my branch** on top of the dev branch, instead of resolving them by merging dev into my own branch


<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->