### PR TITLE
Improved workaround for old dataSyncId containing "||"

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/App.kt
+++ b/app/src/main/java/com/dd3boh/outertune/App.kt
@@ -96,8 +96,12 @@ class App : Application(), ImageLoaderFactory {
                 .map { it[DataSyncIdKey] }
                 .distinctUntilChanged()
                 .collect { dataSyncId ->
-                    YouTube.dataSyncId = dataSyncId
-                        ?.substringBefore("||") // workaround to avoid breaking older installations that have a dataSyncId that contains "||" in it
+                    YouTube.dataSyncId = dataSyncId?.let {
+                        // workaround to avoid breaking older installations that have a dataSyncId that contains "||" in it
+                        // old dataSyncId can only be reused if it was a single id (ends with "||")
+                        it.takeIf { !it.contains("||") }
+                            ?: it.takeIf { it.endsWith("||") }?.substringBefore("||")
+                    }
                 }
         }
         GlobalScope.launch {

--- a/app/src/main/java/com/dd3boh/outertune/App.kt
+++ b/app/src/main/java/com/dd3boh/outertune/App.kt
@@ -97,6 +97,7 @@ class App : Application(), ImageLoaderFactory {
                 .distinctUntilChanged()
                 .collect { dataSyncId ->
                     YouTube.dataSyncId = dataSyncId
+                        ?.substringBefore("||") // workaround to avoid breaking older installations that have a dataSyncId that contains "||" in it
                 }
         }
         GlobalScope.launch {

--- a/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/models/YouTubeClient.kt
@@ -17,32 +17,19 @@ data class YouTubeClient(
     // val origin: String? = null,
     // val referer: String? = null,
 ) {
-    fun toContext(locale: YouTubeLocale, visitorData: String?, dataSyncId: String?): Context {
-        /*
-         * HACK: This is a workaround to avoid breaking older installations that have a dataSyncId
-         * that contains "||" in it.
-         * Return null if the dataSyncId contains "||" to indicate that we should use the default
-         * user.
-         */
-        val onBehalfOfUser = if (dataSyncId?.contains("||") != true)
-            dataSyncId
-        else
-            null
-
-        return Context(
-            client = Context.Client(
-                clientName = clientName,
-                clientVersion = clientVersion,
-                osVersion = osVersion,
-                gl = locale.gl,
-                hl = locale.hl,
-                visitorData = visitorData
-            ),
-            user = Context.User(
-                onBehalfOfUser = onBehalfOfUser
-            ),
-        )
-    }
+    fun toContext(locale: YouTubeLocale, visitorData: String?, dataSyncId: String?) = Context(
+        client = Context.Client(
+            clientName = clientName,
+            clientVersion = clientVersion,
+            osVersion = osVersion,
+            gl = locale.gl,
+            hl = locale.hl,
+            visitorData = visitorData
+        ),
+        user = Context.User(
+            onBehalfOfUser = dataSyncId
+        ),
+    )
 
     companion object {
         /**


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [x] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Better version of https://github.com/OuterTune/OuterTune/commit/81be4c72cb8858f784269896a938a85ffa230e51

- dataSyncId of old installations can be used instead of null
- better performance because code in this place runs less often
- less code



## Due diligence

<!-- Please mark WIP pull requests and "Draft" and only "Ready for review" once it is ready to be merged  -->

- [x] I read the [contribution guidelines](https://github.com/DD3Boh/OuterTune/blob/dev/CONTRIBUTING.md).

### Merge conflict resolution
Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] In the event of merge conflicts, I give permission for the developers to rebase or squash my code or apply merge
  conflict amendments as needed
- [ ] In the event of merge conflicts, I ***DO NOT*** give permission for the developers to modify my code to solve merge
  conflicts. I understand in the event of a merge conflict, I will be responsible to resolve merge conflicts in a way
  that adheres to the [contribution guidelines](https://github.com/DD3Boh/OuterTune/blob/dev/CONTRIBUTING.md)

<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->