### PR TITLE
github: add checklist read checkbox to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,6 +16,8 @@ body:
           required: true
         - label: The title of this issue accurately describes the bug.
           required: true
+        - label: I have NOT read the above checklist.
+          required: false
 
   - type: textarea
     id: reproduce-steps

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,6 +14,8 @@ body:
           required: true
         - label: The title of this issue accurately describes the feature request.
           required: true
+        - label: I have NOT read the above checklist.
+          required: false
 
   - type: textarea
     id: feature-description


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [x] Other

### Description of the changes in your PR

- test if users read when reporting an issue

### Fixes the following issue(s)

- Fixes some users ignoring the issue checklist (maybe)

## Due diligence

<!-- Please mark WIP pull requests and "Draft" and only "Ready for review" once it is ready to be merged  -->

- [x] I read the [contribution guidelines](https://github.com/DD3Boh/OuterTune/blob/dev/CONTRIBUTING.md).

### Merge conflict resolution
Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] In the event of merge conflicts, I give permission for the developers to rebase or squash my code or apply merge
  conflict amendments as needed
- [ ] In the event of merge conflicts, I ***DO NOT*** give permission for the developers to modify my code to solve merge
  conflicts. I understand in the event of a merge conflict, I will be responsible to resolve merge conflicts in a way
  that adheres to the [contribution guidelines](https://github.com/DD3Boh/OuterTune/blob/dev/CONTRIBUTING.md)

<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->