### PR TITLE
app: Do not double decode search query

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
+++ b/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
@@ -238,7 +238,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.net.URLDecoder
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -663,7 +662,7 @@ class MainActivity : ComponentActivity() {
                     LaunchedEffect(navBackStackEntry) {
                         if (navBackStackEntry?.destination?.route?.startsWith("search/") == true) {
                             val searchQuery = withContext(Dispatchers.IO) {
-                                URLDecoder.decode(navBackStackEntry?.arguments?.getString("query")!!, "UTF-8")
+                                navBackStackEntry?.arguments?.getString("query")!!
                             }
                             onQueryChange(TextFieldValue(searchQuery, TextRange(searchQuery.length)))
                         } else if (navigationItems.fastAny { it.route == navBackStackEntry?.destination?.route }) {

--- a/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
+++ b/app/src/main/java/com/dd3boh/outertune/MainActivity.kt
@@ -585,12 +585,7 @@ class MainActivity : ComponentActivity() {
                             if (youtubeNavigator(it.toUri())) {
                                 // don't do anything
                             } else {
-                                val query = if (it[it.lastIndex] == '%') {
-                                    it.substring(0, it.lastIndex)
-                                } else {
-                                    it
-                                }
-                                navController.navigate("search/${query.urlEncode()}")
+                                navController.navigate("search/${it.urlEncode()}")
                                 if (dataStore[PauseSearchHistoryKey] != true) {
                                     database.query {
                                         insert(SearchHistory(query = it))
@@ -870,12 +865,7 @@ class MainActivity : ComponentActivity() {
                                                         if (youtubeNavigator(it.toUri())) {
                                                             return@OnlineSearchScreen
                                                         } else {
-                                                            val query = if (it[it.lastIndex] == '%') {
-                                                                it.substring(0, it.lastIndex)
-                                                            } else {
-                                                                it
-                                                            }
-                                                            navController.navigate("search/${query.urlEncode()}")
+                                                            navController.navigate("search/${it.urlEncode()}")
                                                             if (dataStore[PauseSearchHistoryKey] != true) {
                                                                 database.query {
                                                                     insert(SearchHistory(query = it))


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Compose appears to already be doing this for us, which will cause issues when strings contain '%' signs due to its usage in x-www-form-urlencoded. Fix by removing the final decode checks.

Original report by @josprox, with reference fix provided [1], however the patch includes unnecessary String sanitization which can cause further issues down the line.

[1]: https://github.com/josprox/Joss-Music/commit/ad58ab4930aacb2256436ea4fc1c45172caa80b4

Signed-off-by: Ricky Cheung <rcheung844@gmail.com>
(cherry picked from commit 6b32141da4a637c66992b458e894376e28d3ad78)

### Before/After Screenshots/Screen Record

<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

N/A

### Fixes the following issue(s)

<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (ex: "Fixes #69". Note that each "Fixes #" should be in its own item). Also add any other relevant links. -->

N/A

### Relies on the following changes

<!-- Tag any pull requests that are required before this can be merged.
Delete this if it doesn't apply to your PR. -->

N/A

## Due diligence

<!-- Please mark WIP pull requests and "Draft" and only "Ready for review" once it is ready to be merged  -->

- [x] I read the [contribution guidelines](https://github.com/DD3Boh/OuterTune/blob/dev/CONTRIBUTING.md).

### Merge conflict resolution
Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] In the event of merge conflicts, I give permission for the developers to rebase or squash my code or apply merge
  conflict amendments as needed
- [ ] In the event of merge conflicts, I ***DO NOT*** give permission for the developers to modify my code to solve merge
  conflicts. I understand in the event of a merge conflict, I will be responsible to resolve merge conflicts in a way
  that adheres to the [contribution guidelines](https://github.com/DD3Boh/OuterTune/blob/dev/CONTRIBUTING.md)

<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->