### PR TITLE
ui: progressively load YouTube Music homepage sections

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -170,14 +171,16 @@ fun HomeScreen(
         }
     }
 
-    LaunchedEffect(lazylistState) {
-        val lastVisibleIndex =
-            lazylistState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: return@LaunchedEffect
-        val len = lazylistState.layoutInfo.totalItemsCount
-        if (lastVisibleIndex >= len - 3) {
-            viewModel.loadMoreYouTubeItems(homePage?.continuation)
-        }
+    LaunchedEffect(Unit) {
+        snapshotFlow { lazylistState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
+            .collect { lastVisibleIndex ->
+                val len = lazylistState.layoutInfo.totalItemsCount
+                if (lastVisibleIndex != null && lastVisibleIndex >= len - 3) {
+                    viewModel.loadMoreYouTubeItems(homePage?.continuation)
+                }
+            }
     }
+
 
     val localGridItem: @Composable (LocalItem, String) -> Unit = { it, source ->
         when (it) {

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
@@ -170,6 +170,15 @@ fun HomeScreen(
         }
     }
 
+    LaunchedEffect(lazylistState) {
+        val lastVisibleIndex =
+            lazylistState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: return@LaunchedEffect
+        val len = lazylistState.layoutInfo.totalItemsCount
+        if (lastVisibleIndex >= len - 3) {
+            viewModel.loadMoreYouTubeItems(homePage?.continuation)
+        }
+    }
+
     val localGridItem: @Composable (LocalItem, String) -> Unit = { it, source ->
         when (it) {
             is Song -> SongGridItem(

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/HomeScreen.kt
@@ -708,6 +708,25 @@ fun HomeScreen(
                 }
             }
 
+            if (homePage?.continuation != null) {
+                item {
+                    ShimmerHost(
+                        modifier = Modifier.animateItem()
+                    ) {
+                        TextPlaceholder(
+                            height = 36.dp,
+                            modifier = Modifier
+                                .padding(12.dp)
+                                .width(250.dp),
+                        )
+                        LazyRow {
+                            items(4) {
+                                GridItemPlaceHolder()
+                            }
+                        }
+                    }
+                }
+            }
 
             explorePage?.moodAndGenres?.let { moodAndGenres ->
                 item {

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
@@ -144,16 +144,21 @@ class HomeViewModel @Inject constructor(
 
         isLoading.value = false
     }
-
-
+    
+    private val _isLoadingMore = MutableStateFlow(false)
     fun loadMoreYouTubeItems(continuation: String?) {
-        if (continuation == null) return
+        if (continuation == null || _isLoadingMore.value) return
 
         viewModelScope.launch(Dispatchers.IO) {
-            val nextSections = YouTube.home(continuation).getOrNull() ?: return@launch
+            _isLoadingMore.value = true
+            val nextSections = YouTube.home(continuation).getOrNull() ?: run {
+                _isLoadingMore.value = false
+                return@launch
+            }
             homePage.value = nextSections.copy(
-                homePage.value?.sections.orEmpty() + nextSections.sections
+                sections = homePage.value?.sections.orEmpty() + nextSections.sections
             )
+            _isLoadingMore.value = false
         }
     }
 

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
@@ -147,15 +147,13 @@ class HomeViewModel @Inject constructor(
 
 
     fun loadMoreYouTubeItems(continuation: String?) {
-        if (isRefreshing.value || continuation == null) return
+        if (continuation == null) return
 
         viewModelScope.launch(Dispatchers.IO) {
-            isRefreshing.value = true
             val nextSections = YouTube.home(continuation).getOrNull() ?: return@launch
             homePage.value = nextSections.copy(
                 homePage.value?.sections.orEmpty() + nextSections.sections
             )
-            isRefreshing.value = false
         }
     }
 

--- a/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/dd3boh/outertune/viewmodels/HomeViewModel.kt
@@ -145,6 +145,20 @@ class HomeViewModel @Inject constructor(
         isLoading.value = false
     }
 
+
+    fun loadMoreYouTubeItems(continuation: String?) {
+        if (isRefreshing.value || continuation == null) return
+
+        viewModelScope.launch(Dispatchers.IO) {
+            isRefreshing.value = true
+            val nextSections = YouTube.home(continuation).getOrNull() ?: return@launch
+            homePage.value = nextSections.copy(
+                homePage.value?.sections.orEmpty() + nextSections.sections
+            )
+            isRefreshing.value = false
+        }
+    }
+
     fun refresh() {
         if (isRefreshing.value) return
         viewModelScope.launch(Dispatchers.IO) {

--- a/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/YouTube.kt
@@ -380,9 +380,13 @@ object YouTube {
         }
     }
 
-    suspend fun home(): Result<HomePage> = runCatching {
-        var response = innerTube.browse(WEB_REMIX, browseId = "FEmusic_home").body<BrowseResponse>()
-        var continuation = response.contents?.singleColumnBrowseResultsRenderer?.tabs?.firstOrNull()
+    suspend fun home(continuation: String? = null): Result<HomePage> = runCatching {
+        if (continuation != null) {
+            return@runCatching homeContinuation(continuation).getOrThrow()
+        }
+
+        val response = innerTube.browse(WEB_REMIX, browseId = "FEmusic_home").body<BrowseResponse>()
+        val continuation = response.contents?.singleColumnBrowseResultsRenderer?.tabs?.firstOrNull()
             ?.tabRenderer?.content?.sectionListRenderer?.continuations?.getContinuation()
         val sections = response.contents?.singleColumnBrowseResultsRenderer?.tabs?.firstOrNull()
             ?.tabRenderer?.content?.sectionListRenderer?.contents!!
@@ -390,16 +394,21 @@ object YouTube {
             .mapNotNull {
                 HomePage.Section.fromMusicCarouselShelfRenderer(it)
             }.toMutableList()
-        while (continuation != null) {
-            response = innerTube.browse(WEB_REMIX, continuation = continuation).body<BrowseResponse>()
-            continuation = response.continuationContents?.sectionListContinuation?.continuations?.getContinuation()
-            sections += response.continuationContents?.sectionListContinuation?.contents
-                ?.mapNotNull { it.musicCarouselShelfRenderer }
-                ?.mapNotNull {
-                    HomePage.Section.fromMusicCarouselShelfRenderer(it)
-                }.orEmpty()
-        }
-        HomePage(sections)
+        HomePage(sections, continuation)
+    }
+
+    private suspend fun homeContinuation(continuation: String): Result<HomePage> = runCatching {
+        val response =
+            innerTube.browse(WEB_REMIX, continuation = continuation).body<BrowseResponse>()
+        val continuation =
+            response.continuationContents?.sectionListContinuation?.continuations?.getContinuation()
+        HomePage(
+            response.continuationContents?.sectionListContinuation?.contents
+            ?.mapNotNull { it.musicCarouselShelfRenderer }
+            ?.mapNotNull {
+                HomePage.Section.fromMusicCarouselShelfRenderer(it)
+            }.orEmpty(), continuation
+        )
     }
 
     suspend fun explore(): Result<ExplorePage> = runCatching {

--- a/innertube/src/main/java/com/zionhuang/innertube/pages/HomePage.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/pages/HomePage.kt
@@ -13,6 +13,7 @@ import com.zionhuang.innertube.models.oddElements
 
 data class HomePage(
     val sections: List<Section>,
+    val continuation: String? = null,
 ) {
     data class Section(
         val title: String,


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

### What is it?

- [ ] New feature (user facing)
- [x] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Currently, the full Homepage is loading, including all continuations. Each continuation requires loading the previous one first. By only loading the sections on demand, we can decrease the overall loading time (6-7s to 3-4s on my dev device), as well as reducing the amount of unnecessary requests, as most users are unlikely to completely scroll down every time they use the app.

I've also noticed that the `syncRecentActivity` takes nearly 2s so it might be worth investigating why, or if it could be done in the background.

## Due diligence

<!-- Please mark WIP pull requests and "Draft" and only "Ready for review" once it is ready to be merged  -->

- [x] I read the [contribution guidelines](https://github.com/DD3Boh/OuterTune/blob/dev/CONTRIBUTING.md).

### Merge conflict resolution
Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] In the event of merge conflicts, I give permission for the developers to rebase or squash my code or apply merge
  conflict amendments as needed
- [ ] In the event of merge conflicts, I ***DO NOT*** give permission for the developers to modify my code to solve merge
  conflicts. I understand in the event of a merge conflict, I will be responsible to resolve merge conflicts in a way
  that adheres to the [contribution guidelines](https://github.com/DD3Boh/OuterTune/blob/dev/CONTRIBUTING.md)

<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->