### PR TITLE
strings: be clearer about liked and downloaded playlists

### DIFF
--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -85,7 +85,7 @@ while also allowing users to translate our app as well. New, specific strings to
     <string name="player_background_default">Follow theme</string>
     <string name="player_background_gradient">Gradient</string>
     <string name="player_background_style">Player background style</string>
-    <string name="show_liked_and_downloaded_playlist">Show liked and downloaded playlists in library</string>
+    <string name="show_liked_and_downloaded_playlist">Show playlists for liked and downloaded songs in library</string>
     <string name="slim_navbar_title">Slim navbar</string>
     <string name="slim_navbar_description">Remove text labels to reduce navbar height</string>
     <string name="tab_arrangement">Arrange tabs</string>


### PR DESCRIPTION
it may be confusing to the user or a translator what this refers to, and it may be misunderstood for showing liked/downloaded playlists, not playlists with your liked and downloaded songs.

<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

### What is it?

- [ ] New feature (user facing)
- [x] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- makes the string 'Show liked and downloaded playlists' clearer about its functionality

## Due diligence

<!-- Please mark WIP pull requests and "Draft" and only "Ready for review" once it is ready to be merged  -->

- [x] I read the [contribution guidelines](https://github.com/DD3Boh/OuterTune/blob/dev/CONTRIBUTING.md).

### Merge conflict resolution
Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] In the event of merge conflicts, I give permission for the developers to rebase or squash my code or apply merge
  conflict amendments as needed
- [ ] In the event of merge conflicts, I ***DO NOT*** give permission for the developers to modify my code to solve merge
  conflicts. I understand in the event of a merge conflict, I will be responsible to resolve merge conflicts in a way
  that adheres to the [contribution guidelines](https://github.com/DD3Boh/OuterTune/blob/dev/CONTRIBUTING.md)

<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->