### PR TITLE
fixed crash while trying to download unavailable song

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/playback/DownloadUtil.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/DownloadUtil.kt
@@ -138,38 +138,43 @@ class DownloadUtil @Inject constructor(
                     return@launch
                 }
 
-                val playbackData = runBlocking(Dispatchers.IO) {
-                    YTPlayerUtils.playerResponseForPlayback(
-                        id,
-                        audioQuality = audioQuality,
-                        connectivityManager = connectivityManager,
-                    )
-                }.getOrThrow()
-                val format = playbackData.format
-                database.query {
-                    upsert(
-                        FormatEntity(
-                            id = id,
-                            itag = format.itag,
-                            mimeType = format.mimeType.split(";")[0],
-                            codecs = format.mimeType.split("codecs=")[1].removeSurrounding("\""),
-                            bitrate = format.bitrate,
-                            sampleRate = format.audioSampleRate,
-                            contentLength = format.contentLength!!,
-                            loudnessDb = playbackData.audioConfig?.loudnessDb,
-                            playbackTrackingUrl = playbackData.playbackTracking?.videostatsPlaybackUrl?.baseUrl
+                try {
+                    val playbackData = runBlocking(Dispatchers.IO) {
+                        YTPlayerUtils.playerResponseForPlayback(
+                            id,
+                            audioQuality = audioQuality,
+                            connectivityManager = connectivityManager,
                         )
-                    )
-                }
-                val streamUrl = playbackData.streamUrl.let {
-                    // Specify range to avoid YouTube's throttling
-                    "${it}&range=0-${format.contentLength ?: 10000000}"
-                }
+                    }.getOrThrow()
+                    val format = playbackData.format
+                    database.query {
+                        upsert(
+                            FormatEntity(
+                                id = id,
+                                itag = format.itag,
+                                mimeType = format.mimeType.split(";")[0],
+                                codecs = format.mimeType.split("codecs=")[1].removeSurrounding("\""),
+                                bitrate = format.bitrate,
+                                sampleRate = format.audioSampleRate,
+                                contentLength = format.contentLength!!,
+                                loudnessDb = playbackData.audioConfig?.loudnessDb,
+                                playbackTrackingUrl = playbackData.playbackTracking?.videostatsPlaybackUrl?.baseUrl
+                            )
+                        )
+                    }
+                    val streamUrl = playbackData.streamUrl.let {
+                        // Specify range to avoid YouTube's throttling
+                        "${it}&range=0-${format.contentLength ?: 10000000}"
+                    }
 
-                songUrlCache[id] =
-                    streamUrl to System.currentTimeMillis() + (playbackData.streamExpiresInSeconds * 1000L)
+                    songUrlCache[id] =
+                        streamUrl to System.currentTimeMillis() + (playbackData.streamExpiresInSeconds * 1000L)
 
-                downloadMgr.enqueue(id, streamUrl, displayName = title)
+                    downloadMgr.enqueue(id, streamUrl, displayName = title)
+                } catch (e: PlaybackException) {
+                    Log.w(TAG, "Could not download Song: " + id + e.toString())
+                    database.updateDownloadStatus(id, null)
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

If you add some songs to a playlist, then try to automatically download all songs in the playlist, when OuterTune tries to download a song that is age restricted, not available, or something else, YouTubeDL throws an exception that is not handled. So the whole app crashes. 

### Fixes the following issue(s)

I added a try-catch block that avoids the crash and marks the sog that is not available as not downloaded in the database.

### Relies on the following changes

## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)

<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->