### PR TITLE
Lyrics fixes

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -78,7 +78,7 @@ val MultilineLrcKey = booleanPreferencesKey("multilineLrc")
 val LyricTrimKey = booleanPreferencesKey("lyricTrim")
 val LyricSourcePrefKey = booleanPreferencesKey("preferLocalLyrics")
 val LyricFontSizeKey = intPreferencesKey("lyricFontSize")
-val LyricEmptyClickable = booleanPreferencesKey("lyricEmptyClickable")
+val LyricSyncedClickable = booleanPreferencesKey("lyricEmptyClickable")
 val LyricKaraokeEnable = booleanPreferencesKey("lyricKaraokeEnable")
 val LyricUpdateSpeed = stringPreferencesKey("lyricUpdateSpeed")
 

--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -78,6 +78,7 @@ val MultilineLrcKey = booleanPreferencesKey("multilineLrc")
 val LyricTrimKey = booleanPreferencesKey("lyricTrim")
 val LyricSourcePrefKey = booleanPreferencesKey("preferLocalLyrics")
 val LyricFontSizeKey = intPreferencesKey("lyricFontSize")
+val LyricEmptyClickable = booleanPreferencesKey("lyricEmptyClickable")
 val LyricKaraokeEnable = booleanPreferencesKey("lyricKaraokeEnable")
 val LyricUpdateSpeed = stringPreferencesKey("lyricUpdateSpeed")
 

--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -78,7 +78,7 @@ val MultilineLrcKey = booleanPreferencesKey("multilineLrc")
 val LyricTrimKey = booleanPreferencesKey("lyricTrim")
 val LyricSourcePrefKey = booleanPreferencesKey("preferLocalLyrics")
 val LyricFontSizeKey = intPreferencesKey("lyricFontSize")
-val LyricSyncedClickable = booleanPreferencesKey("lyricEmptyClickable")
+val LyricClickable = booleanPreferencesKey("lyricClickable")
 val LyricKaraokeEnable = booleanPreferencesKey("lyricKaraokeEnable")
 val LyricUpdateSpeed = stringPreferencesKey("lyricUpdateSpeed")
 

--- a/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
@@ -83,7 +83,7 @@ import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.DEFAULT_PLAYER_BACKGROUND
 import com.dd3boh.outertune.constants.DarkMode
 import com.dd3boh.outertune.constants.DarkModeKey
-import com.dd3boh.outertune.constants.LyricEmptyClickable
+import com.dd3boh.outertune.constants.LyricSyncedClickable
 import com.dd3boh.outertune.constants.LyricFontSizeKey
 import com.dd3boh.outertune.constants.LyricKaraokeEnable
 import com.dd3boh.outertune.constants.LyricUpdateSpeed
@@ -131,7 +131,7 @@ fun Lyrics(
     val lyricsTextPosition by rememberEnumPreference(LyricsTextPositionKey, LyricsPosition.CENTER)
     val lyricsFontSize by rememberPreference(LyricFontSizeKey, 20)
 
-    val emptyLyricsClickable by rememberPreference(LyricEmptyClickable, false)
+    val syncedLyricsClickable by rememberPreference(LyricSyncedClickable, true)
     val lyricsFancy by rememberPreference(LyricKaraokeEnable, false)
     val lyricsUpdateSpeed by rememberEnumPreference(LyricUpdateSpeed, Speed.MEDIUM)
     var lyricRefreshRate = lyricsUpdateSpeed.toLrcRefreshMillis()
@@ -338,7 +338,7 @@ fun Lyrics(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 24.dp, vertical = 8.dp)
-                            .clickable(enabled = isSynced && (item.isClickable || emptyLyricsClickable)) {
+                            .clickable(enabled = isSynced && syncedLyricsClickable) {
                                 playerConnection.player.seekTo(item.start.toLong())
                                 currentLineIndex = index
                                 currentPos = item.start.toLong()

--- a/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
@@ -83,6 +83,7 @@ import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.DEFAULT_PLAYER_BACKGROUND
 import com.dd3boh.outertune.constants.DarkMode
 import com.dd3boh.outertune.constants.DarkModeKey
+import com.dd3boh.outertune.constants.LyricEmptyClickable
 import com.dd3boh.outertune.constants.LyricFontSizeKey
 import com.dd3boh.outertune.constants.LyricKaraokeEnable
 import com.dd3boh.outertune.constants.LyricUpdateSpeed
@@ -130,6 +131,7 @@ fun Lyrics(
     val lyricsTextPosition by rememberEnumPreference(LyricsTextPositionKey, LyricsPosition.CENTER)
     val lyricsFontSize by rememberPreference(LyricFontSizeKey, 20)
 
+    val emptyLyricsClickable by rememberPreference(LyricEmptyClickable, false)
     val lyricsFancy by rememberPreference(LyricKaraokeEnable, false)
     val lyricsUpdateSpeed by rememberEnumPreference(LyricUpdateSpeed, Speed.MEDIUM)
     var lyricRefreshRate = lyricsUpdateSpeed.toLrcRefreshMillis()
@@ -335,7 +337,7 @@ fun Lyrics(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 24.dp, vertical = 8.dp)
-                            .clickable(enabled = isSynced && item.isClickable) {
+                            .clickable(enabled = isSynced && (item.isClickable || emptyLyricsClickable)) {
                                 playerConnection.player.seekTo(item.start.toLong())
                                 lastPreviewTime = 0L
                                 haptic.performHapticFeedback(HapticFeedbackType.ToggleOn)

--- a/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
@@ -218,6 +218,7 @@ fun Lyrics(
         while (isActive) {
             // TODO: likely can improve power usage by disabling lyric refresh
             delay(lyricRefreshRate)
+            if (!playerConnection.isPlaying.value) continue
             val sliderPosition = sliderPositionProvider()
             isSeeking = sliderPosition != null
             currentLineIndex = findCurrentLineIndex(lines, sliderPosition ?: playerConnection.player.currentPosition)
@@ -339,6 +340,8 @@ fun Lyrics(
                             .padding(horizontal = 24.dp, vertical = 8.dp)
                             .clickable(enabled = isSynced && (item.isClickable || emptyLyricsClickable)) {
                                 playerConnection.player.seekTo(item.start.toLong())
+                                currentLineIndex = index
+                                currentPos = item.start.toLong()
                                 lastPreviewTime = 0L
                                 haptic.performHapticFeedback(HapticFeedbackType.ToggleOn)
                             }

--- a/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
@@ -216,7 +216,6 @@ fun Lyrics(
         while (isActive) {
             // TODO: likely can improve power usage by disabling lyric refresh
             delay(lyricRefreshRate)
-            if (!playerConnection.isPlaying.value) continue
             val sliderPosition = sliderPositionProvider()
             isSeeking = sliderPosition != null
             currentLineIndex = findCurrentLineIndex(lines, sliderPosition ?: playerConnection.player.currentPosition)

--- a/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
@@ -554,7 +554,7 @@ fun splitTextToLines(
  */
 fun findCurrentLineIndex(lines: List<LyricLine>, position: Long): Int {
     for (index in lines.indices) {
-        if (lines[index].start >= (position).toUInt()) {
+        if (lines[index].start > (position).toUInt()) {
             return index - 1
         }
     }

--- a/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
@@ -83,7 +83,7 @@ import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.DEFAULT_PLAYER_BACKGROUND
 import com.dd3boh.outertune.constants.DarkMode
 import com.dd3boh.outertune.constants.DarkModeKey
-import com.dd3boh.outertune.constants.LyricSyncedClickable
+import com.dd3boh.outertune.constants.LyricClickable
 import com.dd3boh.outertune.constants.LyricFontSizeKey
 import com.dd3boh.outertune.constants.LyricKaraokeEnable
 import com.dd3boh.outertune.constants.LyricUpdateSpeed
@@ -131,7 +131,7 @@ fun Lyrics(
     val lyricsTextPosition by rememberEnumPreference(LyricsTextPositionKey, LyricsPosition.CENTER)
     val lyricsFontSize by rememberPreference(LyricFontSizeKey, 20)
 
-    val syncedLyricsClickable by rememberPreference(LyricSyncedClickable, true)
+    val lyricsClickable by rememberPreference(LyricClickable, true)
     val lyricsFancy by rememberPreference(LyricKaraokeEnable, false)
     val lyricsUpdateSpeed by rememberEnumPreference(LyricUpdateSpeed, Speed.MEDIUM)
     var lyricRefreshRate = lyricsUpdateSpeed.toLrcRefreshMillis()
@@ -338,7 +338,8 @@ fun Lyrics(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 24.dp, vertical = 8.dp)
-                            .clickable(enabled = isSynced && syncedLyricsClickable) {
+                            // we allow clicking on blank lyrics, ignore item.isClickable
+                            .clickable(enabled = isSynced && lyricsClickable) {
                                 playerConnection.player.seekTo(item.start.toLong())
                                 currentLineIndex = index
                                 currentPos = item.start.toLong()

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/LyricFrag.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/LyricFrag.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.res.stringResource
 import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.EnableKugouKey
 import com.dd3boh.outertune.constants.EnableLrcLibKey
-import com.dd3boh.outertune.constants.LyricEmptyClickable
+import com.dd3boh.outertune.constants.LyricSyncedClickable
 import com.dd3boh.outertune.constants.LyricFontSizeKey
 import com.dd3boh.outertune.constants.LyricSourcePrefKey
 import com.dd3boh.outertune.constants.LyricTrimKey
@@ -103,7 +103,7 @@ fun ColumnScope.LyricFormatFrag() {
 fun ColumnScope.LyricParserFrag() {
     val (multilineLrc, onMultilineLrcChange) = rememberPreference(MultilineLrcKey, defaultValue = true)
     val (lyricTrim, onLyricTrimChange) = rememberPreference(LyricTrimKey, defaultValue = false)
-    val (emptyLyricClickable, onEmptyLyricClickable) = rememberPreference(LyricEmptyClickable, defaultValue = false)
+    val (syncedLyricsClickable, onSyncedLyricsClickable) = rememberPreference(LyricSyncedClickable, defaultValue = true)
 
     // multiline lyrics
     SwitchPreference(
@@ -122,13 +122,13 @@ fun ColumnScope.LyricParserFrag() {
         onCheckedChange = onLyricTrimChange
     )
 
-    // Are empty lyrics clickable?
+    // Are synced lyrics clickable?
     SwitchPreference(
         title = { Text(stringResource(R.string.lyrics_empty_clickable)) },
         description = stringResource(R.string.lyrics_empty_clickable_description),
         icon = { Icon(Icons.Rounded.TouchApp, null) },
-        checked = emptyLyricClickable,
-        onCheckedChange = onEmptyLyricClickable
+        checked = syncedLyricsClickable,
+        onCheckedChange = onSyncedLyricsClickable
     )
 }
 

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/LyricFrag.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/LyricFrag.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.res.stringResource
 import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.EnableKugouKey
 import com.dd3boh.outertune.constants.EnableLrcLibKey
-import com.dd3boh.outertune.constants.LyricSyncedClickable
+import com.dd3boh.outertune.constants.LyricClickable
 import com.dd3boh.outertune.constants.LyricFontSizeKey
 import com.dd3boh.outertune.constants.LyricSourcePrefKey
 import com.dd3boh.outertune.constants.LyricTrimKey
@@ -45,6 +45,7 @@ fun ColumnScope.LyricFormatFrag() {
         LyricsTextPositionKey,
         defaultValue = LyricsPosition.CENTER
     )
+    val (syncedLyricsClickable, onSyncedLyricsClickable) = rememberPreference(LyricClickable, defaultValue = true)
 
     val (lyricFontSize, onLyricFontSizeChange) = rememberPreference(LyricFontSizeKey, defaultValue = 20)
 
@@ -70,6 +71,13 @@ fun ColumnScope.LyricFormatFrag() {
         description = "$lyricFontSize sp",
         icon = { Icon(Icons.Rounded.TextFields, null) },
         onClick = { showFontSizeDialog = true }
+    )
+    // clickable lyrics
+    SwitchPreference(
+        title = { Text(stringResource(R.string.lyrics_synced_clickable)) },
+        icon = { Icon(Icons.Rounded.TouchApp, null) },
+        checked = syncedLyricsClickable,
+        onCheckedChange = onSyncedLyricsClickable
     )
 
 
@@ -103,7 +111,6 @@ fun ColumnScope.LyricFormatFrag() {
 fun ColumnScope.LyricParserFrag() {
     val (multilineLrc, onMultilineLrcChange) = rememberPreference(MultilineLrcKey, defaultValue = true)
     val (lyricTrim, onLyricTrimChange) = rememberPreference(LyricTrimKey, defaultValue = false)
-    val (syncedLyricsClickable, onSyncedLyricsClickable) = rememberPreference(LyricSyncedClickable, defaultValue = true)
 
     // multiline lyrics
     SwitchPreference(
@@ -120,15 +127,6 @@ fun ColumnScope.LyricParserFrag() {
         icon = { Icon(Icons.Rounded.ContentCut, null) },
         checked = lyricTrim,
         onCheckedChange = onLyricTrimChange
-    )
-
-    // Are synced lyrics clickable?
-    SwitchPreference(
-        title = { Text(stringResource(R.string.lyrics_synced_clickable)) },
-        description = stringResource(R.string.lyrics_synced_clickable_description),
-        icon = { Icon(Icons.Rounded.TouchApp, null) },
-        checked = syncedLyricsClickable,
-        onCheckedChange = onSyncedLyricsClickable
     )
 }
 

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/LyricFrag.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/LyricFrag.kt
@@ -124,8 +124,8 @@ fun ColumnScope.LyricParserFrag() {
 
     // Are synced lyrics clickable?
     SwitchPreference(
-        title = { Text(stringResource(R.string.lyrics_empty_clickable)) },
-        description = stringResource(R.string.lyrics_empty_clickable_description),
+        title = { Text(stringResource(R.string.lyrics_synced_clickable)) },
+        description = stringResource(R.string.lyrics_synced_clickable_description),
         icon = { Icon(Icons.Rounded.TouchApp, null) },
         checked = syncedLyricsClickable,
         onCheckedChange = onSyncedLyricsClickable

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/LyricFrag.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/LyricFrag.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.automirrored.rounded.Sort
 import androidx.compose.material.icons.rounded.ContentCut
 import androidx.compose.material.icons.rounded.Lyrics
 import androidx.compose.material.icons.rounded.TextFields
+import androidx.compose.material.icons.rounded.TouchApp
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -24,6 +25,7 @@ import androidx.compose.ui.res.stringResource
 import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.EnableKugouKey
 import com.dd3boh.outertune.constants.EnableLrcLibKey
+import com.dd3boh.outertune.constants.LyricEmptyClickable
 import com.dd3boh.outertune.constants.LyricFontSizeKey
 import com.dd3boh.outertune.constants.LyricSourcePrefKey
 import com.dd3boh.outertune.constants.LyricTrimKey
@@ -101,6 +103,7 @@ fun ColumnScope.LyricFormatFrag() {
 fun ColumnScope.LyricParserFrag() {
     val (multilineLrc, onMultilineLrcChange) = rememberPreference(MultilineLrcKey, defaultValue = true)
     val (lyricTrim, onLyricTrimChange) = rememberPreference(LyricTrimKey, defaultValue = false)
+    val (emptyLyricClickable, onEmptyLyricClickable) = rememberPreference(LyricEmptyClickable, defaultValue = false)
 
     // multiline lyrics
     SwitchPreference(
@@ -117,6 +120,15 @@ fun ColumnScope.LyricParserFrag() {
         icon = { Icon(Icons.Rounded.ContentCut, null) },
         checked = lyricTrim,
         onCheckedChange = onLyricTrimChange
+    )
+
+    // Are empty lyrics clickable?
+    SwitchPreference(
+        title = { Text(stringResource(R.string.lyrics_empty_clickable)) },
+        description = stringResource(R.string.lyrics_empty_clickable_description),
+        icon = { Icon(Icons.Rounded.TouchApp, null) },
+        checked = emptyLyricClickable,
+        onCheckedChange = onEmptyLyricClickable
     )
 }
 

--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -161,6 +161,8 @@ while also allowing users to translate our app as well. New, specific strings to
     <string name="lyrics_prefer_local_description">Prioritize resolving local lyric files before using all cloud providers. Turn this off to prioritize cloud providers</string>
     <string name="lyrics_settings_title">Lyrics</string>
     <string name="lyrics_trim_title">Remove spaces around lyrics</string>
+    <string name="lyrics_empty_clickable">Clickable empty lyrics</string>
+    <string name="lyrics_empty_clickable_description">Toggle if empty lyrics are clickable or not.</string>
 
 <!-- Local player settings -->
     <string name="local_library_enable_title">Enable local media</string>

--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -161,8 +161,8 @@ while also allowing users to translate our app as well. New, specific strings to
     <string name="lyrics_prefer_local_description">Prioritize resolving local lyric files before using all cloud providers. Turn this off to prioritize cloud providers</string>
     <string name="lyrics_settings_title">Lyrics</string>
     <string name="lyrics_trim_title">Remove spaces around lyrics</string>
-    <string name="lyrics_empty_clickable">Clickable synced lyrics</string>
-    <string name="lyrics_empty_clickable_description">Toggle if synced lyrics are clickable or not.</string>
+    <string name="lyrics_synced_clickable">Clickable synced lyrics</string>
+    <string name="lyrics_synced_clickable_description">Toggle if synced lyrics are clickable or not.</string>
 
 <!-- Local player settings -->
     <string name="local_library_enable_title">Enable local media</string>

--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -161,8 +161,8 @@ while also allowing users to translate our app as well. New, specific strings to
     <string name="lyrics_prefer_local_description">Prioritize resolving local lyric files before using all cloud providers. Turn this off to prioritize cloud providers</string>
     <string name="lyrics_settings_title">Lyrics</string>
     <string name="lyrics_trim_title">Remove spaces around lyrics</string>
-    <string name="lyrics_empty_clickable">Clickable empty lyrics</string>
-    <string name="lyrics_empty_clickable_description">Toggle if empty lyrics are clickable or not.</string>
+    <string name="lyrics_empty_clickable">Clickable synced lyrics</string>
+    <string name="lyrics_empty_clickable_description">Toggle if synced lyrics are clickable or not.</string>
 
 <!-- Local player settings -->
     <string name="local_library_enable_title">Enable local media</string>

--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -160,9 +160,8 @@ while also allowing users to translate our app as well. New, specific strings to
     <string name="lyrics_prefer_local">Prefer local lyric files</string>
     <string name="lyrics_prefer_local_description">Prioritize resolving local lyric files before using all cloud providers. Turn this off to prioritize cloud providers</string>
     <string name="lyrics_settings_title">Lyrics</string>
+    <string name="lyrics_synced_clickable">Clickable lyrics</string>
     <string name="lyrics_trim_title">Remove spaces around lyrics</string>
-    <string name="lyrics_synced_clickable">Clickable synced lyrics</string>
-    <string name="lyrics_synced_clickable_description">Toggle if synced lyrics are clickable or not.</string>
 
 <!-- Local player settings -->
     <string name="local_library_enable_title">Enable local media</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

- From version 0.8.1 to 0.9, there were a few changes to how lyrics work, this pull request tweaks those.
- A config option has been added to toggle whether empty lyrics are clickable to seek to them. This always worked in 0.8.1 and before, and has been disabled since 0.9.
- Tapping lyrics would sometimes seek to the previous lyric, which has been fixed.
- Tapping lyrics while paused would not seek until unpaused again, this has been fixed.
- This is mostly just a bunch of minor tweaks

### Before/After Screenshots/Screen Record
- Before:
Empty lyrics not being clickable

https://github.com/user-attachments/assets/88464e93-500a-409f-a2d5-688187c0554d

Lyrics seek not working while paused

https://github.com/user-attachments/assets/ca08f803-8115-46a2-b1ce-3901185abf97

Lyrics seek to the previous lyric

https://github.com/user-attachments/assets/0db25d74-77b0-4603-9d81-0261c565fcb8


- After:
Empty lyrics clickable with config

https://github.com/user-attachments/assets/4b24e73e-e70b-4dd5-8eee-f67f5b361ddf

Lyrics seek works while paused

https://github.com/user-attachments/assets/2a6ee87b-3243-4500-b9b4-8ecfbeb70e22

Lyrics seek to the correct lyric

https://github.com/user-attachments/assets/9406b6b1-8c29-44e2-b777-679032dd46fc


## Due diligence

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)