### PR TITLE
Use PipePipe Extractor to resolve playback issues

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,7 +82,8 @@ junit = { group = "junit", name = "junit", version = "4.13.2" }
 taglib = { group = "com.github.Kyant0", name = "taglib", version.ref = "taglib" }
 
 #newpipe-extractor = { group = "com.github.TeamNewPipe", name = "NewPipeExtractor", version = "v0.24.5" }
-newpipe-extractor = { group = "com.github.libre-tube", name = "NewPipeExtractor", version = "bcb7705" }
+#newpipe-extractor = { group = "com.github.libre-tube", name = "NewPipeExtractor", version = "bcb7705" }
+newpipe-extractor = { group = "com.github.InfinityLoop1308", name = "PipePipeExtractor", version = "4240401" }
 
 
 [plugins]

--- a/innertube/src/main/java/com/zionhuang/innertube/NewPipe.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/NewPipe.kt
@@ -56,7 +56,11 @@ private class NewPipeDownloaderImpl(proxy: Proxy?) : Downloader() {
         val responseBodyToReturn = response.body?.string()
 
         val latestUrl = response.request.url.toString()
-        return Response(response.code, response.message, response.headers.toMultimap(), responseBodyToReturn, latestUrl)
+        return Response(response.code, response.message, response.headers.toMultimap(), responseBodyToReturn, responseBodyToReturn?.toByteArray(), latestUrl)
+    }
+
+    override fun executeAsync(request: Request, callback: AsyncCallback?): CancellableCall {
+        TODO("Placeholder")
     }
 
 }

--- a/innertube/src/main/java/com/zionhuang/innertube/NewPipe.kt
+++ b/innertube/src/main/java/com/zionhuang/innertube/NewPipe.kt
@@ -7,6 +7,7 @@ import io.ktor.http.parseQueryString
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.schabi.newpipe.extractor.NewPipe
+import org.schabi.newpipe.extractor.downloader.CancellableCall
 import org.schabi.newpipe.extractor.downloader.Downloader
 import org.schabi.newpipe.extractor.downloader.Request
 import org.schabi.newpipe.extractor.downloader.Response


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [x] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in my PR

<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->

#### The problem

There are a bunch of problems listed in #468 that occur due to broken deobfuscation which causes payback using WEB_REMIX and TVHTML5_SIMPLY_EMBEDDED_PLAYER clients to fail, so that it falls back to IOS client, which gets blocked by YouTube resulting in playback taking only 30 seconds. The corresponding [issue](https://github.com/TeamNewPipe/NewPipeExtractor/issues/1287) in NewPipe Extractor appears to be fixed, but in reality, it doesn't work.

#### The solution

There's a fork of NewPipe Extractor, called [PipePipe Extractor](https://github.com/InfinityLoop1308/PipePipeExtractor), that works properly, that's it. Substituting LibreTube's NewPipe Extractor with PipePipe Extractor, magically solves the problem and this is essentially all that this PR changes.

### Related to the following issue

<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (ex: "Fixes #69". Note that each "Fixes #" should be in its own item). Also add any other relevant links. -->

- #468

I'm not sure if this PR fixes _all_ the problems listed in the issue, but the following (which are the most common) are definitely fixed:

- Playback Error 403
- Source error 2004
- Playback stops after 30 seconds

So, at least, you will be able to scrap those from the list.

## Due diligence

<!-- Please mark WIP pull requests and "Draft" and only "Ready for review" once it is ready to be merged  -->

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)

<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->