### PR TITLE
fastlane: separate full description into multiple lines

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,1 +1,19 @@
-<p><i>OuterTune</i> is a supercharged fork of <a href="https://github.com/z-huang/InnerTune" target="_blank" rel="nofollow noopener">InnerTune</a>. This app is both a local media player, and a YouTube Music client.</p><p></p>Features:<p></p><ul><li>YouTube Music client with song downloading (offline playback), background playback, no ADs, and account synchronization</li><li>Local audio file playback (MP3, OGG, FLAC, etc.)</li><li>Uses a custom tag extractor instead of MediaStore's broken metadata extractor! (e.g tags delimited with \\ now show up properly)</li><li>Play local and Youtube Music songs at the same time</li><li>New integrated library screen design</li><li>Multiple queues</li><li>Synchronized lyrics, and support for word by word/Karaoke lyrics (e.g LRC, TTML) </li><li>Audio normalization, tempo/pitch adjustment, and various other audio effects</li><li>Android Auto support</li></ul><p></p>Notice:<p></p><ul><li>Android 8 (Oreo) and higher is supported. While the app may work on Android 7.x, we do not officially support this version</li><li>OuterTune is in a "stable beta" phase. While this app can certainly be used as your main music player, be aware there is a possibility of bugs, incomplete features, or any other unexpected behaviour. Please report issues on our Github page!</li><li>Please visit our wiki for more information including FAQs, guides, and manuals: <a href="https://github.com/OuterTune/OuterTune/wiki/Frequently-Asked-Questions-(FAQ)">https://github.com/OuterTune/OuterTune/wiki/Frequently-Asked-Questions-(FAQ)</a></li></ul>
+<p><i>OuterTune</i> is a supercharged fork of <a href="https://github.com/z-huang/InnerTune" target="_blank" rel="nofollow noopener">InnerTune</a>. This app is both a local media player, and a YouTube Music client.</p>
+
+<p></p>Features:<p></p>
+
+<ul>
+<li>YouTube Music client with song downloading (offline playback), background playback, no ADs, and account synchronization</li>
+<li>Local audio file playback (MP3, OGG, FLAC, etc.)</li><li>Uses a custom tag extractor instead of MediaStore's broken metadata extractor! (e.g tags delimited with \\ now show up properly)</li>
+<li>Play local and Youtube Music songs at the same time</li><li>New integrated library screen design</li><li>Multiple queues</li>
+<li>Synchronized lyrics, and support for word by word/Karaoke lyrics (e.g LRC, TTML) </li>
+<li>Audio normalization, tempo/pitch adjustment, and various other audio effects</li>
+<li>Android Auto support</li>
+</ul>
+
+<p></p>Notice:<p></p>
+<ul>
+<li>Android 8 (Oreo) and higher is supported. While the app may work on Android 7.x, we do not officially support this version</li>
+<li>OuterTune is in a "stable beta" phase. While this app can certainly be used as your main music player, be aware there is a possibility of bugs, incomplete features, or any other unexpected behaviour. Please report issues on our Github page!</li>
+<li>Please visit our wiki for more information including FAQs, guides, and manuals: <a href="https://github.com/OuterTune/OuterTune/wiki/Frequently-Asked-Questions-(FAQ)">https://github.com/OuterTune/OuterTune/wiki/Frequently-Asked-Questions-(FAQ)</a></li>
+</ul>

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,16 +1,16 @@
 <p><i>OuterTune</i> is a supercharged fork of <a href="https://github.com/z-huang/InnerTune" target="_blank" rel="nofollow noopener">InnerTune</a>. This app is both a local media player, and a YouTube Music client.</p>
 
-<p></p>Features:<p></p>
+<p><br><b>Features:</b></p>
 <ul>
 <li>YouTube Music client with song downloading (offline playback), background playback, no ADs, and account synchronization</li>
-<li>Local audio file playback (MP3, OGG, FLAC, etc.)</li><li>Uses a custom tag extractor instead of MediaStore's broken metadata extractor! (e.g tags delimited with \\ now show up properly)</li>
+<li>Local audio file playback (MP3, OGG, FLAC, etc.)</li><li>Uses a custom tag extractor instead of MediaStore's broken metadata extractor! (e.g tags delimited with backslash now show up properly)</li>
 <li>Play local and Youtube Music songs at the same time</li><li>New integrated library screen design</li><li>Multiple queues</li>
 <li>Synchronized lyrics, and support for word by word/Karaoke lyrics (e.g LRC, TTML) </li>
 <li>Audio normalization, tempo/pitch adjustment, and various other audio effects</li>
 <li>Android Auto support</li>
 </ul>
 
-<p></p>Notice:<p></p>
+<p><br><b>Notice:</b></p>
 <ul>
 <li>Android 8 (Oreo) and higher is supported. While the app may work on Android 7.x, we do not officially support this version</li>
 <li>OuterTune is in a "stable beta" phase. While this app can certainly be used as your main music player, be aware there is a possibility of bugs, incomplete features, or any other unexpected behaviour. Please report issues on our Github page!</li>

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,7 +1,6 @@
 <p><i>OuterTune</i> is a supercharged fork of <a href="https://github.com/z-huang/InnerTune" target="_blank" rel="nofollow noopener">InnerTune</a>. This app is both a local media player, and a YouTube Music client.</p>
 
 <p></p>Features:<p></p>
-
 <ul>
 <li>YouTube Music client with song downloading (offline playback), background playback, no ADs, and account synchronization</li>
 <li>Local audio file playback (MP3, OGG, FLAC, etc.)</li><li>Uses a custom tag extractor instead of MediaStore's broken metadata extractor! (e.g tags delimited with \\ now show up properly)</li>


### PR DESCRIPTION
so translating isn't messy

Doing all this in a single string is confusing when it comes to translating

<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [x] Other

### Description of the changes in your PR

Make Fastlane's full description more easily translateable by trying to mirror how it is visualized


-

## Due diligence

<!-- Please mark WIP pull requests and "Draft" and only "Ready for review" once it is ready to be merged  -->

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)

<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->