### PR TITLE
songs: Option to keep lyrics strong after listening

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/dd3boh/outertune/constants/PreferenceKeys.kt
@@ -77,6 +77,8 @@ val ShowLyricsKey = booleanPreferencesKey("showLyrics")
 val LyricsTextPositionKey = stringPreferencesKey("lyricsTextPosition")
 val MultilineLrcKey = booleanPreferencesKey("multilineLrc")
 val LyricTrimKey = booleanPreferencesKey("lyricTrim")
+
+val lyricHeardOpacityKey = booleanPreferencesKey("lyricHeardOpacity")
 val LyricSourcePrefKey = booleanPreferencesKey("preferLocalLyrics")
 val LyricFontSizeKey = intPreferencesKey("lyricFontSize")
 val LyricClickable = booleanPreferencesKey("lyricClickable")

--- a/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/component/Lyrics.kt
@@ -82,9 +82,11 @@ import com.dd3boh.outertune.R
 import com.dd3boh.outertune.constants.LyricClickable
 import com.dd3boh.outertune.constants.LyricFontSizeKey
 import com.dd3boh.outertune.constants.LyricKaraokeEnable
+import com.dd3boh.outertune.constants.LyricTrimKey
 import com.dd3boh.outertune.constants.LyricUpdateSpeed
 import com.dd3boh.outertune.constants.LyricsPosition
 import com.dd3boh.outertune.constants.LyricsTextPositionKey
+import com.dd3boh.outertune.constants.lyricHeardOpacityKey
 import com.dd3boh.outertune.constants.ShowLyricsKey
 import com.dd3boh.outertune.constants.Speed
 import com.dd3boh.outertune.db.entities.LyricsEntity
@@ -125,6 +127,8 @@ fun Lyrics(
 
     val lyricsTextPosition by rememberEnumPreference(LyricsTextPositionKey, LyricsPosition.CENTER)
     val lyricsFontSize by rememberPreference(LyricFontSizeKey, 20)
+
+    val lyricHeardOpacity by rememberPreference(lyricHeardOpacityKey, defaultValue = false)
 
     val lyricsClickable by rememberPreference(LyricClickable, true)
     val lyricsFancy by rememberPreference(LyricKaraokeEnable, false)
@@ -393,7 +397,12 @@ fun Lyrics(
                                     if (!isSynced || ((index == displayedCurrentLineIndex || (index == displayedCurrentLineIndex + 1 && item.isTranslated)))) {
                                         1f
                                     } else {
-                                        0.5f
+                                        if(index < displayedCurrentLineIndex && lyricHeardOpacity){
+                                            1f
+                                        } else{
+                                            0.5f
+                                        }
+
                                     }
                                 )
                             )

--- a/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/LyricFrag.kt
+++ b/app/src/main/java/com/dd3boh/outertune/ui/screens/settings/fragments/LyricFrag.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.Sort
 import androidx.compose.material.icons.rounded.ContentCut
+import androidx.compose.material.icons.rounded.Gradient
 import androidx.compose.material.icons.rounded.Lyrics
 import androidx.compose.material.icons.rounded.Speed
 import androidx.compose.material.icons.rounded.TextFields
@@ -38,6 +39,7 @@ import com.dd3boh.outertune.constants.LyricFontSizeKey
 import com.dd3boh.outertune.constants.LyricKaraokeEnable
 import com.dd3boh.outertune.constants.LyricSourcePrefKey
 import com.dd3boh.outertune.constants.LyricTrimKey
+import com.dd3boh.outertune.constants.lyricHeardOpacityKey
 import com.dd3boh.outertune.constants.LyricUpdateSpeed
 import com.dd3boh.outertune.constants.LyricsPosition
 import com.dd3boh.outertune.constants.LyricsTextPositionKey
@@ -53,6 +55,8 @@ import com.dd3boh.outertune.utils.rememberPreference
 
 @Composable
 fun ColumnScope.LyricFormatFrag() {
+    val (lyricHeardOpacity, onlyricHeardOpacityChange) = rememberPreference(lyricHeardOpacityKey, defaultValue = false)
+
     val (lyricsPosition, onLyricsPositionChange) = rememberEnumPreference(
         LyricsTextPositionKey,
         defaultValue = LyricsPosition.CENTER
@@ -81,6 +85,13 @@ fun ColumnScope.LyricFormatFrag() {
         description = "$lyricFontSize sp",
         icon = { Icon(Icons.Rounded.TextFields, null) },
         onClick = { showFontSizeDialog = true }
+    )
+
+    SwitchPreference(
+        title = { Text(stringResource(R.string.lyrics_heard_opacity)) },
+        icon = { Icon(Icons.Rounded.Gradient, null) },
+        checked = lyricHeardOpacity,
+        onCheckedChange = onlyricHeardOpacityChange
     )
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -337,4 +337,5 @@ We recycle translations from upstream, they are pulled periodically. -->
     <string name="new_version_available">New version available</string>
     <string name="translation_models">Translation Models</string>
     <string name="clear_translation_models">Clear translation models</string>
+    <string name="lyrics_heard_opacity">Lyrics already heard remain opacity</string>
 </resources>


### PR DESCRIPTION
(OBS: It is my first pull request, so I might have done something wrong here. I welcome feedback.)

Added a new option to keep the lyrics of the song that has already been listened to with strong opacity

<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

### What is it?

- [ ] New feature (user facing)
- [X] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->
Added a new option in the lyrics settings to keep the lyrics of the song that has already been listened to with strong opacity.

- record videos
- create clones
- take over the world

### Before/After Screenshots/Screen Record

<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
<img width="935" height="511" alt="image" src="https://github.com/user-attachments/assets/fb2fe0ad-4254-44da-8b47-a10bb2ec55da" />

### Fixes the following issue(s)

<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (ex: "Fixes #69". Note that each "Fixes #" should be in its own item). Also add any other relevant links. -->

- Fixes #

### Relies on the following changes

<!-- Tag any pull requests that are required before this can be merged.
Delete this if it doesn't apply to your PR. -->

-

## Due diligence

<!-- Please mark WIP pull requests and "Draft" and only "Ready for review" once it is ready to be merged  -->

- [X] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE. If you select none, or both, the first selection will used as your final choice

- [X] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)

<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->