### PR TITLE
translations: The about page has inconsistencies in its translation f…

### DIFF
--- a/app/src/main/res/values/strings-ot.xml
+++ b/app/src/main/res/values/strings-ot.xml
@@ -100,9 +100,9 @@ while also allowing users to translate our app as well. New, specific strings to
     <string name="checking_for_update">Checking for updates</string>
     <string name="device_info_title">Device information</string>
     <string name="ffmpeg_lgpl">This software uses libraries from the FFmpeg project under the LGPLv2.1</string>
-    <string name="help_bug_report_action">Submit a bug report (Via GitHub)</string>
-    <string name="help_contact_email_inquiries">Other inquires (Tap to copy Email)</string>
-    <string name="help_support_forum">Help and support (Via GitHub)</string>
+    <string name="help_bug_report_action">Submit a bug report (via GitHub)</string>
+    <string name="help_contact_email_inquiries">Other inquires (tap to copy email)</string>
+    <string name="help_support_forum">Help and support (via GitHub)</string>
     <string name="no_updates_available">No updates available</string>
     <string name="oss_licenses_title">Open source licenses</string>
     <string name="wiki">Wiki</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving OuterTune, and filling out the details. Having roughly the same layout helps everyone considerably :)-->

### What is it?

- [ ] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [X] Other

### Description of the changes in your PR

The about page has inconsistencies in its translation from English to other languages, the issue says that the words shouldn't be capitalized (and in fact they shouldn't). Looking at the translation, I saw that they don't keep the letters capitalized, so I changed it to keep them uncapitalized. In other translations, "email" is translated as "e-mail" should I change this in the original as well to be consistent?

<!-- While bullet points are the norm in this section, feel free to write free-form text instead of a list -->

### Before/After Screenshots/Screen Record

- Before
<img width="218" height="756" alt="image" src="https://github.com/user-attachments/assets/6ab6bd39-206b-4f89-9b64-69d2285d4f87" />


- After
<img width="204" height="742" alt="image" src="https://github.com/user-attachments/assets/f1e82d2e-3a84-423e-981f-4b32d82f3286" />


<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

### Fixes the following issue(s)

<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (ex: "Fixes #69". Note that each "Fixes #" should be in its own item). Also add any other relevant links. -->

- Fixes #842

OBS: I made a mistake in my last pull request, the last implementation fixed two fixes.

## Due diligence

<!-- Please mark WIP pull requests and "Draft" and only "Ready for review" once it is ready to be merged  -->

- [X] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE. If you select none, or both, the first selection will used as your final choice

- [X] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)

<!-- This pull request template is based on Newpipe's:  https://github.com/TeamNewPipe/NewPipe/ -->