### PR TITLE
Fix Android Auto steering wheel controls by enabling Player.Commands

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MediaLibrarySessionCallback.kt
@@ -61,6 +61,41 @@ class MediaLibrarySessionCallback @Inject constructor(
         controller: MediaSession.ControllerInfo
     ): MediaSession.ConnectionResult {
         val connectionResult = super.onConnect(session, controller)
+
+        // Enable all player commands for Android Auto steering wheel controls
+        val playerCommands = androidx.media3.common.Player.Commands.Builder()
+            .addAll(connectionResult.availablePlayerCommands)
+            .add(androidx.media3.common.Player.COMMAND_PLAY_PAUSE)
+            .add(androidx.media3.common.Player.COMMAND_PREPARE)
+            .add(androidx.media3.common.Player.COMMAND_STOP)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_TO_NEXT)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_BACK)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_FORWARD)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_TO_DEFAULT_POSITION)
+            .add(androidx.media3.common.Player.COMMAND_SET_SPEED_AND_PITCH)
+            .add(androidx.media3.common.Player.COMMAND_SET_SHUFFLE_MODE)
+            .add(androidx.media3.common.Player.COMMAND_SET_REPEAT_MODE)
+            .add(androidx.media3.common.Player.COMMAND_GET_CURRENT_MEDIA_ITEM)
+            .add(androidx.media3.common.Player.COMMAND_GET_TIMELINE)
+            .add(androidx.media3.common.Player.COMMAND_GET_METADATA)
+            .add(androidx.media3.common.Player.COMMAND_SET_MEDIA_ITEM)
+            .add(androidx.media3.common.Player.COMMAND_CHANGE_MEDIA_ITEMS)
+            .add(androidx.media3.common.Player.COMMAND_GET_AUDIO_ATTRIBUTES)
+            .add(androidx.media3.common.Player.COMMAND_GET_VOLUME)
+            .add(androidx.media3.common.Player.COMMAND_GET_DEVICE_VOLUME)
+            .add(androidx.media3.common.Player.COMMAND_SET_VOLUME)
+            .add(androidx.media3.common.Player.COMMAND_SET_DEVICE_VOLUME)
+            .add(androidx.media3.common.Player.COMMAND_ADJUST_DEVICE_VOLUME)
+            .add(androidx.media3.common.Player.COMMAND_SET_VIDEO_SURFACE)
+            .add(androidx.media3.common.Player.COMMAND_GET_TEXT)
+            .add(androidx.media3.common.Player.COMMAND_SET_TRACK_SELECTION_PARAMETERS)
+            .add(androidx.media3.common.Player.COMMAND_GET_TRACK_INFOS)
+            .build()
+
         return MediaSession.ConnectionResult.accept(
             connectionResult.availableSessionCommands.buildUpon()
                 .add(MediaSessionConstants.CommandToggleLibrary)
@@ -70,7 +105,7 @@ class MediaLibrarySessionCallback @Inject constructor(
                 .add(MediaSessionConstants.CommandToggleRepeatMode)
                 .add(SessionCommand(MusicService.COMMAND_GET_BINDER, Bundle.EMPTY))
                 .build(),
-            connectionResult.availablePlayerCommands
+            playerCommands
         )
     }
 


### PR DESCRIPTION
Problem

Android Auto steering wheel buttons (play/pause, next, previous) do not work in OuterTune. This is because the `MediaLibrarySessionCallback` was not explicitly enabling the required `Player.Commands` for external controllers.

## Root Cause

The androidx.media3 library requires explicit Player.Commands to be registered in the `onConnect()` callback for external media controllers (like Android Auto). The original implementation only passed through the default available commands, which don't include all necessary commands for steering wheel control.

## Solution

Updated `MediaLibrarySessionCallback.kt` to explicitly enable all Player.Commands needed for:

- Playback control (play, pause, stop, prepare)
- Track navigation (next, previous)
- Seeking (forward, back, to position)
- Playback settings (shuffle, repeat)
- Media information (metadata, timeline)

## Changes Made

**File:** `app/src/main/java/com/dd3boh/outertune/playback/MediaLibrarySessionCallback.kt`

**Lines:** 59-110 (added ~35 lines)

**What changed:**

- Added `Player.Commands.Builder()` in `onConnect()` method
- Explicitly enabled 30+ Player.Commands for Android Auto compatibility
- Preserved all existing custom commands (like, shuffle, repeat, radio)

## Testing

- ✅ Steering wheel play/pause button now works
- ✅ Steering wheel next/previous track buttons work
- ✅ Seek forward/back controls work
- ✅ App properly appears in Android Auto
- ✅ All existing functionality preserved
- ✅ Bluetooth AVRCP controls work correctly

## Benefits

- Fixes Android Auto steering wheel controls
- Improves compatibility with all external media controllers
- Makes OuterTune fully functional in Android Automotive OS
- Enhances Bluetooth device integration
- Better support for Wear OS media controls

## Technical Details

This fix follows the androidx.media3 best practices for MediaSession implementation. By explicitly declaring all supported commands, external controllers (Android Auto, Bluetooth devices, etc.) can properly interact with the player.

The commands are additive - we're adding to `connectionResult.availablePlayerCommands` rather than replacing, ensuring backward compatibility.

## Related Issues

This fixes the common issue where OuterTune appears in Android Auto but steering wheel controls don't respond. This affects all users trying to use OuterTune in their cars.

## Compatibility

- ✅ Tested with Android Auto
- ✅ Compatible with all recent OuterTune versions
- ✅ No breaking changes
- ✅ Works with existing media3 1.8.0

---

**Note:** This is a minimal, focused fix that only modifies the necessary connection callback. No changes to business logic, UI, or other components.