### PR TITLE
player: Fix Android Auto steering wheel controls

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/java/com/dd3boh/outertune/playback/MediaLibrarySessionCallback.kt
@@ -61,6 +61,41 @@ class MediaLibrarySessionCallback @Inject constructor(
         controller: MediaSession.ControllerInfo
     ): MediaSession.ConnectionResult {
         val connectionResult = super.onConnect(session, controller)
+
+        // Enable all player commands for Android Auto steering wheel controls
+        val playerCommands = androidx.media3.common.Player.Commands.Builder()
+            .addAll(connectionResult.availablePlayerCommands)
+            .add(androidx.media3.common.Player.COMMAND_PLAY_PAUSE)
+            .add(androidx.media3.common.Player.COMMAND_PREPARE)
+            .add(androidx.media3.common.Player.COMMAND_STOP)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_TO_NEXT)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_BACK)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_FORWARD)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
+            .add(androidx.media3.common.Player.COMMAND_SEEK_TO_DEFAULT_POSITION)
+            .add(androidx.media3.common.Player.COMMAND_SET_SPEED_AND_PITCH)
+            .add(androidx.media3.common.Player.COMMAND_SET_SHUFFLE_MODE)
+            .add(androidx.media3.common.Player.COMMAND_SET_REPEAT_MODE)
+            .add(androidx.media3.common.Player.COMMAND_GET_CURRENT_MEDIA_ITEM)
+            .add(androidx.media3.common.Player.COMMAND_GET_TIMELINE)
+            .add(androidx.media3.common.Player.COMMAND_GET_METADATA)
+            .add(androidx.media3.common.Player.COMMAND_SET_MEDIA_ITEM)
+            .add(androidx.media3.common.Player.COMMAND_CHANGE_MEDIA_ITEMS)
+            .add(androidx.media3.common.Player.COMMAND_GET_AUDIO_ATTRIBUTES)
+            .add(androidx.media3.common.Player.COMMAND_GET_VOLUME)
+            .add(androidx.media3.common.Player.COMMAND_GET_DEVICE_VOLUME)
+            .add(androidx.media3.common.Player.COMMAND_SET_VOLUME)
+            .add(androidx.media3.common.Player.COMMAND_SET_DEVICE_VOLUME)
+            .add(androidx.media3.common.Player.COMMAND_ADJUST_DEVICE_VOLUME)
+            .add(androidx.media3.common.Player.COMMAND_SET_VIDEO_SURFACE)
+            .add(androidx.media3.common.Player.COMMAND_GET_TEXT)
+            .add(androidx.media3.common.Player.COMMAND_SET_TRACK_SELECTION_PARAMETERS)
+            .add(androidx.media3.common.Player.COMMAND_GET_TRACK_INFOS)
+            .build()
+
         return MediaSession.ConnectionResult.accept(
             connectionResult.availableSessionCommands.buildUpon()
                 .add(MediaSessionConstants.CommandToggleLibrary)
@@ -70,7 +105,7 @@ class MediaLibrarySessionCallback @Inject constructor(
                 .add(MediaSessionConstants.CommandToggleRepeatMode)
                 .add(SessionCommand(MusicService.COMMAND_GET_BINDER, Bundle.EMPTY))
                 .build(),
-            connectionResult.availablePlayerCommands
+            playerCommands
         )
     }
 


### PR DESCRIPTION
- Add explicit Player.Commands in MediaLibrarySessionCallback
- Enable all playback, navigation, and control commands for external controllers
- Fixes steering wheel buttons not responding in Android Auto
- Improves compatibility with Bluetooth and other external media controllers


### What is it?

- [x] New feature (user facing)
- [ ] Update to existing feature (user facing)
- [ ] Bugfix (user facing)
- [ ] Codebase improvements or refactors (dev facing)
- [ ] Other

### Description of the changes in your PR

Updated `MediaLibrarySessionCallback.kt` to explicitly enable all Player.Commands needed for:

- Playback control (play, pause, stop, prepare)
- Track navigation (next, previous)
- Seeking (forward, back, to position)
- Playback settings (shuffle, repeat)
- Media information (metadata, timeline)

Changes Made:

**File:** `app/src/main/java/com/dd3boh/outertune/playback/MediaLibrarySessionCallback.kt`

**Lines:** 59-110 (added ~35 lines)

**What changed:**

- Added `Player.Commands.Builder()` in `onConnect()` method
- Explicitly enabled 30+ Player.Commands for Android Auto compatibility
- Preserved all existing custom commands (like, shuffle, repeat, radio)

### Before/After Screenshots/Screen Record

<!-- If your PR changes the app's UI in any way, please include screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

- Before: N/A
- After: N/A

### Fixes the following issue(s)

- Fixes #941 

https://github.com/OuterTune/OuterTune/issues/941

-

- [x] I have read and agreed to the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md).

### Merging strategy / Merge conflict resolution

Select only ONE. If you select none, or both, the first selection will used as your final choice

- [x] When merging this pull request, or in the event of merge conflicts, I give permission for the merger to rebase,
  or squash my code, or apply merge conflict amendments as needed
- [ ] When merging this pull request, or in the event of merge conflicts, I ***DO NOT*** give permission for the
  merger to modify my code to solve merge conflicts. I understand in the event of a merge conflict, I will be
  responsible to resolve merge conflicts in a way that adheres to
  the [contribution guidelines](https://github.com/OuterTune/OuterTune/blob/dev/CONTRIBUTING.md)