### PR TITLE
fix(YTPlayerUtils): Improve stream validation error handling

### DIFF
--- a/app/src/main/java/com/dd3boh/outertune/utils/YTPlayerUtils.kt
+++ b/app/src/main/java/com/dd3boh/outertune/utils/YTPlayerUtils.kt
@@ -174,16 +174,17 @@ object YTPlayerUtils {
                     streamUrl += "&pot=$webStreamingPot";
                 }
 
-                if (clientIndex == STREAM_FALLBACK_CLIENTS.size - 1) {
-                    /** skip [validateStatus] for last client */
-                    break
-                }
                 if (validateStatus(streamUrl)) {
                     // working stream found
                     Log.i(TAG, "[$videoId] [${client.clientName}] found working stream")
                     break
                 } else {
                     Log.w(TAG, "[$videoId] [${client.clientName}] got bad http status code")
+                    // Don't use invalid streams - continue to next client or fail
+                    if (clientIndex == STREAM_FALLBACK_CLIENTS.size - 1) {
+                        // Last client also failed validation - clear the URL so we throw an error
+                        streamUrl = null
+                    }
                 }
             }
         }
@@ -202,10 +203,18 @@ object YTPlayerUtils {
             throw Exception("Missing stream expire time")
         }
         if (format == null) {
-            throw Exception("Could not find format")
+            throw PlaybackException(
+                "Could not find audio format",
+                null,
+                PlaybackException.ERROR_CODE_REMOTE_ERROR
+            )
         }
         if (streamUrl == null) {
-            throw Exception("Could not find stream url")
+            throw PlaybackException(
+                "Could not find working stream URL - all clients failed validation",
+                null,
+                PlaybackException.ERROR_CODE_REMOTE_ERROR
+            )
         }
 
         Log.d(TAG, "[$videoId] stream url: $streamUrl")


### PR DESCRIPTION
## What is it?

- [ ] New feature (user-facing)
- [ ] Update to existing feature (user-facing)
- [x] Bug fix (user-facing)
- [ ] Codebase improvements or refactors (dev-facing)
- [ ] Other

---

## Description of Changes

This PR fixes a silent playback failure that occurred when clicking the play button.

Previously, stream URL validation was skipped for the final fallback client (iOS). This could result in invalid or broken stream URLs being used, causing playback to fail silently without any error message.

### Summary of changes
- Stream URL validation is now performed for **all clients**, including the final fallback client.
- If the final fallback client also fails validation, `streamUrl` is set to `null` to trigger proper error handling.
- Replaced generic `Exception` usage with `PlaybackException` for stream format and URL errors.
- Added clearer, user-facing error messages (e.g. *"Could not find working stream URL — all clients failed validation"*).

---

## Before / After

**Before**
- Clicking the play button could result in silence with no user feedback when all YouTube stream clients failed validation.

**After**
- Users now receive a clear error message explaining that playback failed, instead of experiencing unexplained silence.

---

## Fixes

- Fixes #[YOUR_ISSUE_NUMBER]  
  *(Clicking the play button results in silence instead of playback)*

---

## Dependencies

- None

---

## Due Diligence

- [x] I have read and agreed to the contribution guidelines.

---

## Merging Strategy / Merge Conflict Resolution

- [x] I give permission for the maintainer to rebase, squash, or amend commits as needed when merging this pull request.
